### PR TITLE
Expiration time for data

### DIFF
--- a/app/server/store/redis.py
+++ b/app/server/store/redis.py
@@ -75,6 +75,15 @@ class BaseRedisStoreSession(StoreSession):
     async def hgetall(self, key: str) -> dict[bytes, bytes]:
         return await self.client.hgetall(key)
 
+    async def expire_at(self, key: str, expire_at: int):
+        await self.pipe.expireat(key, expire_at)
+
+    async def expire_time(self, key: str) -> int:
+        return await self.pipe.expiretime(key)  # type: ignore
+
+    async def ttl(self, key: str, ttl: int):
+        await self.pipe.expire(key, ttl)
+
 
 class RedisStoreSession(BaseRedisStoreSession):
     def __init__(self, pool: aioredis.ConnectionPool):

--- a/app/server/store/store.py
+++ b/app/server/store/store.py
@@ -91,6 +91,15 @@ class StoreSession(ABC):
     @abstractmethod
     async def hgetall(self, key: str) -> dict[bytes, bytes]: ...
 
+    @abstractmethod
+    async def expire_at(self, key: str, expire_at: int): ...
+
+    @abstractmethod
+    async def expire_time(self, key: str) -> int: ...
+
+    @abstractmethod
+    async def ttl(self, key: str, ttl: int): ...
+
 
 class Store(ABC):
     async def __aenter__(self):

--- a/app/server/tasks/callback.py
+++ b/app/server/tasks/callback.py
@@ -5,7 +5,7 @@ import requests
 from azure.storage.blob import BlobClient
 from pydantic import BaseModel
 
-from ..case import get_aliases
+from ..case import CaseStore
 from ..config import config
 from ..generated.models import (
     Document,
@@ -109,7 +109,9 @@ def get_aliases_sync(jurisdiction_id: str, case_id: str) -> list[MaskedSubject]:
     async def _get_aliases_with_store() -> list[MaskedSubject]:
         async with config.queue.store.driver() as store:
             async with store.tx() as tx:
-                return await get_aliases(tx, jurisdiction_id, case_id)
+                cs = CaseStore(tx)
+                await cs.init(jurisdiction_id, case_id)
+                return await cs.get_aliases()
 
     return asyncio.run(_get_aliases_with_store())
 


### PR DESCRIPTION
 - Only keep case data for a specified TTL.
 - TTL is kept consistent across all records pertaining to a case, so it'll all automatically get expunged at once. 
 - Further refactoring to abstract all store interactions further away from Redis.