### PR TITLE
Improve test infrastructure

### DIFF
--- a/app/server/test_app.py
+++ b/app/server/test_app.py
@@ -1,7 +1,34 @@
 from fastapi.testclient import TestClient
+from glowplug import DbDriver
+
+from .db import Exposure, ReviewType
 
 
 async def test_health(api: TestClient):
     response = api.get("/api/v1/health")
     assert response.status_code == 200
     assert response.json() == {"detail": "ok"}
+
+
+async def test_exposure_blind(api: TestClient, exp_db: DbDriver):
+    request = {
+        "jurisdictionId": "jur1",
+        "caseId": "case1",
+        "subjectId": "sub1",
+        "reviewingAttorneyMaskedId": "att1",
+        "documentIds": ["doc1"],
+        "protocol": "BLIND_REVIEW",
+    }
+    response = api.post("/api/v1/exposure", json=request)
+    assert response.status_code == 200
+
+    with exp_db.sync_session() as sesh:
+        exps = sesh.query(Exposure).all()
+        assert len(exps) == 1
+        exp = exps[0]
+        assert exp.jurisdiction_id == "jur1"
+        assert exp.case_id == "case1"
+        assert exp.subject_id == "sub1"
+        assert exp.document_ids == '["doc1"]'
+        assert exp.reviewer_id == "att1"
+        assert exp.review_type == ReviewType.blind

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import tempfile
 from datetime import datetime
@@ -6,9 +7,7 @@ import pytest
 import pytz
 from fastapi.testclient import TestClient
 
-os.environ["VALIDATE_TOKEN"] = "no"
-
-TEST_CONFIG = """\
+DEFAULT_TEST_CONFIG_TPL = """\
 debug = true
 
 [queue]
@@ -24,34 +23,67 @@ automigrate = true
 
 [experiments.store]
 engine = "sqlite"
-path = ":memory:"
+path = "{db_path}"
 
 [processor]
 pipe = [
-    { engine = "extract:tesseract" },
-    { engine = "redact:noop", delimiters = ["[", "]"] },
-    { engine = "render:text" },
+    {{ engine = "extract:tesseract" }},
+    {{ engine = "redact:noop", delimiters = ["[", "]"] }},
+    {{ engine = "render:text" }},
 ]
 """
 
-tmp_config = tempfile.NamedTemporaryFile()
-tmp_config.write(TEST_CONFIG.encode("utf-8"))
-tmp_config.flush()
-os.environ["CONFIG_PATH"] = tmp_config.name
+os.environ["VALIDATE_TOKEN"] = "no"
 
 
 @pytest.fixture
-async def config():
+def logger():
+    return logging.getLogger(__name__)
+
+
+@pytest.fixture
+async def sqlite_db_path(request, logger):
+    db_path = getattr(request, "param", None)
+    if db_path:
+        logger.debug("Using existing SQLite database: %s", db_path)
+        with open(db_path, "w") as f:
+            f.write("")
+        yield db_path
+    else:
+        logger.debug("Creating temporary SQLite database ...")
+        with tempfile.NamedTemporaryFile() as tmp_db:
+            logger.debug("Using temporary SQLite database: %s", tmp_db.name)
+            yield tmp_db.name
+
+
+@pytest.fixture
+async def config(sqlite_db_path, request, logger):
     from app.server.config import config
 
-    yield config
+    os.environ["VALIDATE_TOKEN"] = "no"
+
+    cfg_tpl = getattr(request, "param", DEFAULT_TEST_CONFIG_TPL)
+    cfg = cfg_tpl.format(db_path=sqlite_db_path)
+
+    with tempfile.NamedTemporaryFile() as tmp_config:
+        # Write new config to a temporary file
+        tmp_config.write(cfg.encode("utf-8"))
+        tmp_config.flush()
+
+        # Reset the config in memory to point to new file.
+        config._reset(tmp_config.name)
+        logger.debug(f"Using config: {tmp_config.name}")
+        logger.debug(f"Full Config:\n===\n\n{cfg}\n\n===")
+
+        yield config
 
 
 @pytest.fixture
 async def exp_db(config):
-    from app.server.db import Base
+    from app.server.db import init_db
 
-    await config.experiments.store.driver.init(Base, drop_first=True)
+    await init_db(config.experiments.store.driver, drop_first=True)
+
     yield config.experiments.store.driver
 
 
@@ -62,13 +94,14 @@ async def qstore(config):
 
 
 @pytest.fixture
-def now(request):
+def now(request, logger):
     default_now = datetime(2024, 1, 1, 0, 0, 0)
     dt = getattr(request, "param", default_now)
     # Make sure to use a timezone-aware datetime. By default, the timezone is UTC.
     # If we don't do this, the tests will fail when run in a different timezone.
     if not dt.tzinfo:
         dt = pytz.utc.localize(dt)
+    logger.debug("What time is it? now = %s", dt)
     return lambda: dt
 
 


### PR DESCRIPTION
 - Rewrites `conftest.py` and `config.py` to remove global config objects.
 - `Config` is now lazily loaded on the first attribute access.
 - `Config` object can also be reloaded in memory after the initial load.
 - The app config is now a fixture that can be configured per test.
 - Temporary files for the DB and the config are now cleaned up properly when the test session ends.
 - Better logging in `conftest.py` for debugging issues with config, by using `--log-level=DEBUG` flag to `pytest`
 - Adds a new test for exposure logging to prove new test changes.