### PR TITLE
Support for application gateway, WAF

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -21,22 +21,63 @@ provider "registry.terraform.io/azure/azapi" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/azurerm" {
-  version     = "4.0.1"
-  constraints = "~> 4.0.1"
+provider "registry.terraform.io/chilicat/pkcs12" {
+  version     = "0.2.5"
+  constraints = "~> 0.2.5"
   hashes = [
-    "h1:cbblXI9nw+Hp6T2E0tjfYU570kLpiqBKV+dJHQGa3a4=",
-    "zh:0e78a9200eef138d08050aab99c4fb9ab99c7c5ccbdd410592db7acc5ed421fe",
-    "zh:443157ba089ef4002817c4f3b3610654588084c2d8c8cf00f1ddf708c7c73411",
-    "zh:563595dd72b894b2ef9825226c04689ea9967113568a06077960cd863b3afa36",
-    "zh:5bef3c6bc8306b607078a09c3ab1d2ee55435e0099eedca459aca6c259c29079",
-    "zh:5eb305ca10a14a5cf5308e7225779f9f4152d5a8dd842c901fa47fc93432b346",
-    "zh:6041a5272b293ae95b46a39ceced3f14bf267a379263c10d11301c50c2e740d0",
-    "zh:7b077b9358ef6878d0520febcf17ba651eda6636c66885c925ae27d20df6d575",
-    "zh:8a140a1f8eb35a5ab5b5d3d46759d45408ad14dc5ca3f7fc9af5dc5cf1bb2133",
-    "zh:9a9d707dbd3b111a28e914a277e1e1076221a41194f7eaa0389e0b4a9b4033e4",
-    "zh:e8c42fb6cde74ecae1fe0a5fd9bb4bd804a5441f8dfec9d3cb4966af2054ede4",
-    "zh:eb018fe31c8e6f3e495bd79c7b278aa7dc51b48453f6b83bdb0e7b13459b2aa0",
+    "h1:1vZ8tUrI8o3xWJmbJD7IBxEXCXsVg1C547aCdEvKj5E=",
+    "zh:099802a505ee961a4e456f34a58a5c7f6333ba86e582159c24343b0ed2d2bf80",
+    "zh:32ef46c47a9ce814090b104591597aa510ee4887e20409b5143b5c7d69a7b55f",
+    "zh:3beca52da17cdc21a5fff21b0c7831ab59e902f7027ad324368a006d55dcb1db",
+    "zh:5aa1d56ac8fa29856cfe3cb3f85039689ae7c6e3a22cdacd2c7029d390726dc6",
+    "zh:679b8d9464f731a3ac8e6d4cdacb45e34fd5daa1ea418f11e6f775e23b7898db",
+    "zh:69d88672e9e232a8194df9f5a439b5f010bc53069fab55a59375ee78ae45bbc2",
+    "zh:76daedfc797921a78a9e07f579607cf06eea48b0eeec2af000bd86245ddc31cc",
+    "zh:83a9963982452304d5a402368270ffb188d1ebe39d86a692e0ad93917aeee09f",
+    "zh:a1e80c898b82afb0894fa2b7de2812c7f9f7121f8ac992923f0181a09bfb4301",
+    "zh:a6ae8f1f9f9f12ad15eb14fc5d6aa289a1eba355965b21453498cf369748e848",
+    "zh:b1d4dee7e26ddb9142fe179c29c07228df14efe616afd60f3a6b0ba31e51e0bf",
+    "zh:c11edc4b753d003ae3c4635826fce6bc4953f032d7b0cf7c340ff91f33f020e8",
+    "zh:cad6a44202247ca3f6a59d230fd449feadc3c7797afdcebc0337719a1005486f",
+    "zh:f2b7e798d5b07003e8930ca6b8fd66caaa5afc64c5c496584851adc0de5e525a",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.2.0"
+  constraints = "~> 4.2.0"
+  hashes = [
+    "h1:PAoaAXX0Sl3XIYrBXv7wro6NXWahwXOtQ3pgCDnOMlw=",
+    "zh:44d84b8a5f2bc6a71a32d85b706200d4dbb2b6a2a9babb25193a852fbbdb9e23",
+    "zh:57633b586c7b73b169d047a25dd2aa8931ba86bfea22f8e54228b849525708d6",
+    "zh:58f4e6a80cbc3ad5c92b9c6352f8b1fce6fa0b8a3231e1317bc9b3efba605355",
+    "zh:a2e2cc82b0d018abe8a9535dcbc173f55b36354fe9778941bdd71c975999fb52",
+    "zh:a7040aac14e384137f263f1d31a6183556a5acedcc19679647f0deda3c42ba1b",
+    "zh:c476526f7d54766b627758134a9340984888bacd41954dd11239cbe9b592fc46",
+    "zh:d001651de98256162c6dc351f4a22d446b6a77d65c487a59bd987d6783a93e71",
+    "zh:d7bffe913c2fb2a2b7abcf7d747c707a03182a2dc0dbd60a7b5da7a8c7705c3d",
+    "zh:e2b04f060c72050e7b53582edaaae10d1ed41d07a07babc933c04e9f600a4542",
+    "zh:eed6694ca700dae58f4a1aa12e02c58d2bfb0a2f09be72f43608bb1ffe709b6b",
+    "zh:f29200bafe66af9700dc3eb23aa2430a68d5e3dfdd3fc41ad7ceab743c10e164",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "4.0.6"
+  hashes = [
+    "h1:n3M50qfWfRSpQV9Pwcvuse03pEizqrmYEryxKky4so4=",
+    "zh:10de0d8af02f2e578101688fd334da3849f56ea91b0d9bd5b1f7a243417fdda8",
+    "zh:37fc01f8b2bc9d5b055dc3e78bfd1beb7c42cfb776a4c81106e19c8911366297",
+    "zh:4578ca03d1dd0b7f572d96bd03f744be24c726bfd282173d54b100fd221608bb",
+    "zh:6c475491d1250050765a91a493ef330adc24689e8837a0f07da5a0e1269e11c1",
+    "zh:81bde94d53cdababa5b376bbc6947668be4c45ab655de7aa2e8e4736dfd52509",
+    "zh:abdce260840b7b050c4e401d4f75c7a199fafe58a8b213947a258f75ac18b3e8",
+    "zh:b754cebfc5184873840f16a642a7c9ef78c34dc246a8ae29e056c79939963c7a",
+    "zh:c928b66086078f9917aef0eec15982f2e337914c5c4dbc31dd4741403db7eb18",
+    "zh:cded27bee5f24de6f2ee0cfd1df46a7f88e84aaffc2ecbf3ff7094160f193d50",
+    "zh:d65eb3867e8f69aaf1b8bb53bd637c99c6b649ba3db16ded50fa9a01076d1a27",
+    "zh:ecb0c8b528c7a619fa71852bb3fb5c151d47576c5aab2bf3af4db52588722eeb",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -18,8 +18,13 @@ resource "azurerm_container_app_environment" "main" {
   }
 }
 
+locals {
+  app_name = format("%s-rbc-app", var.partner)
+  app_fqdn = format("%s.%s", local.app_name, azurerm_container_app_environment.main.default_domain)
+}
+
 resource "azurerm_container_app" "main" {
-  name                         = format("%s-rbc-app", var.partner)
+  name                         = local.app_name
   resource_group_name          = azurerm_resource_group.main.name
   container_app_environment_id = azurerm_container_app_environment.main.id
   tags                         = var.tags

--- a/terraform/db.tf
+++ b/terraform/db.tf
@@ -28,7 +28,7 @@ resource "azurerm_private_endpoint" "mssql" {
   name                = format("%s-rbc-mssql-pe", var.partner)
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
-  subnet_id           = azurerm_subnet.default.id
+  subnet_id           = azurerm_subnet.db.id
   private_service_connection {
     name                           = "mssql-psc"
     private_connection_resource_id = azurerm_mssql_server.main.id

--- a/terraform/form_recognizer.tf
+++ b/terraform/form_recognizer.tf
@@ -12,7 +12,7 @@ resource "azurerm_private_endpoint" "fr" {
   name                = format("%s-rbc-cs-fr-pe", var.partner)
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
-  subnet_id           = azurerm_subnet.default.id
+  subnet_id           = azurerm_subnet.fr.id
   private_service_connection {
     name                           = "cs-fr-psc"
     private_connection_resource_id = azurerm_cognitive_account.fr.id

--- a/terraform/gateway.tf
+++ b/terraform/gateway.tf
@@ -1,0 +1,149 @@
+locals {
+  app_gateway_name                = format("%s-rbc-app-gw", var.partner)
+  frontend_ip_config_name         = format("%s-rbc-app-gw-feip", var.partner)
+  frontend_https_port_name        = format("%s-rbc-app-gw-feport-http", var.partner)
+  https_listener_name             = format("%s-rbc-app-gw-listener", var.partner)
+  backend_address_pool_name       = format("%s-rbc-app-gw-be-pool", var.partner)
+  backend_http_settings_name      = format("%s-rbc-app-gw-be-settings", var.partner)
+  ssl_cert_name                   = format("%s-rbc-app-gw-cert", var.partner)
+  private_link_configuration_name = format("%s-rbc-app-gw-plc", var.partner)
+  probe_name                      = format("%s-rbc-app-gw-probe", var.partner)
+}
+
+
+### SHADY CERTIFICATE THINGS ###
+# NOTE(jnu) -- This self-signed certificate is ONLY useful for bootstrapping
+# a quick environment for testing. In production, exposed apps need to use
+# a real certificate issued for a real custom domain.
+resource "tls_private_key" "app_gateway" {
+  count     = var.expose_app ? 1 : 0
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "tls_self_signed_cert" "app_gateway" {
+  count           = var.expose_app ? 1 : 0
+  private_key_pem = tls_private_key.app_gateway[0].private_key_pem
+  subject {
+    common_name  = local.app_fqdn
+    organization = format("%s Race Blind Charging", var.partner)
+  }
+  validity_period_hours = 8760
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+}
+
+resource "pkcs12_from_pem" "app_gateway" {
+  count           = var.expose_app ? 1 : 0
+  password        = var.ssl_cert_password
+  private_key_pem = tls_private_key.app_gateway[0].private_key_pem
+  cert_pem        = tls_self_signed_cert.app_gateway[0].cert_pem
+}
+
+### END SHADY CERTIFICATE THINGS ###
+
+resource "azurerm_application_gateway" "public" {
+  count               = var.expose_app ? 1 : 0
+  name                = local.app_gateway_name
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+
+  sku {
+    name     = var.waf ? "WAF_v2" : "Standard_v2"
+    tier     = var.waf ? "WAF_v2" : "Standard_v2"
+    capacity = 2
+  }
+
+  waf_configuration {
+    enabled            = var.waf
+    firewall_mode      = "Prevention"
+    rule_set_type      = "OWASP"
+    rule_set_version   = "3.2"
+    request_body_check = false
+  }
+
+  gateway_ip_configuration {
+    name      = format("%s-rbc-app-gw-ip", var.partner)
+    subnet_id = azurerm_subnet.gateway.id
+  }
+
+  frontend_port {
+    name = local.frontend_https_port_name
+    port = 443
+  }
+
+  frontend_ip_configuration {
+    name                            = local.frontend_ip_config_name
+    public_ip_address_id            = azurerm_public_ip.gateway[0].id
+    private_link_configuration_name = local.private_link_configuration_name
+  }
+
+  frontend_ip_configuration {
+    name                          = format("%s-rbc-app-gw-feip-priv", var.partner)
+    private_ip_address_allocation = "Static"
+    private_ip_address            = "10.0.6.66"
+    subnet_id                     = azurerm_subnet.gateway.id
+  }
+
+  backend_address_pool {
+    name  = local.backend_address_pool_name
+    fqdns = [local.app_fqdn]
+  }
+
+  backend_http_settings {
+    name                                = local.backend_http_settings_name
+    probe_name                          = local.probe_name
+    cookie_based_affinity               = "Disabled"
+    port                                = 443
+    protocol                            = "Https"
+    request_timeout                     = 20
+    pick_host_name_from_backend_address = true
+  }
+
+  ssl_certificate {
+    name     = local.ssl_cert_name
+    data     = pkcs12_from_pem.app_gateway[0].result
+    password = var.ssl_cert_password
+  }
+
+  http_listener {
+    name                           = local.https_listener_name
+    frontend_ip_configuration_name = local.frontend_ip_config_name
+    frontend_port_name             = local.frontend_https_port_name
+    protocol                       = "Https"
+    ssl_certificate_name           = local.ssl_cert_name
+  }
+
+  request_routing_rule {
+    priority                   = 1
+    name                       = format("%s-rbc-app-gw-rr", var.partner)
+    rule_type                  = "Basic"
+    http_listener_name         = local.https_listener_name
+    backend_address_pool_name  = local.backend_address_pool_name
+    backend_http_settings_name = local.backend_http_settings_name
+
+  }
+
+  probe {
+    name                                      = local.probe_name
+    protocol                                  = "Https"
+    pick_host_name_from_backend_http_settings = true
+    path                                      = "/api/v1/health"
+    interval                                  = 30
+    timeout                                   = 30
+    unhealthy_threshold                       = 3
+  }
+
+  private_link_configuration {
+    name = local.private_link_configuration_name
+    ip_configuration {
+      name                          = format("%s-rbc-app-gw-plcipcfg", var.partner)
+      subnet_id                     = azurerm_subnet.gateway-pl.id
+      private_ip_address_allocation = "Dynamic"
+      primary                       = true
+    }
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2,11 +2,15 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0.1"
+      version = "~> 4.2.0"
     }
     azapi = {
       source  = "azure/azapi"
       version = "~> 1.15.0"
+    }
+    pkcs12 = {
+      source  = "chilicat/pkcs12"
+      version = "~> 0.2.5"
     }
   }
 
@@ -26,6 +30,8 @@ provider "azapi" {
   subscription_id = var.subscription_id
   environment     = var.azure_env
 }
+
+provider "pkcs12" {}
 
 data "azurerm_client_config" "current" {}
 

--- a/terraform/openai.tf
+++ b/terraform/openai.tf
@@ -60,7 +60,7 @@ resource "azurerm_private_endpoint" "openai" {
   name                = format("%s-rbc-cs-oai-pe", var.partner)
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
-  subnet_id           = azurerm_subnet.default.id
+  subnet_id           = azurerm_subnet.openai.id
   private_service_connection {
     name                           = "cs-oai-psc"
     private_connection_resource_id = azurerm_cognitive_account.openai.id

--- a/terraform/redis.tf
+++ b/terraform/redis.tf
@@ -13,7 +13,7 @@ resource "azurerm_private_endpoint" "redis" {
   name                = format("%s-rbc-redis-pe", var.partner)
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
-  subnet_id           = azurerm_subnet.default.id
+  subnet_id           = azurerm_subnet.redis.id
 
   private_service_connection {
     name                           = "redis-psc"

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -44,6 +44,19 @@ variable "expose_app" {
   description = "Expose the app outside of the app environment."
 }
 
+variable "waf" {
+  type        = bool
+  default     = true
+  description = "Enable the Web Application Firewall for the application gateway."
+}
+
+variable "ssl_cert_password" {
+  type        = string
+  sensitive   = true
+  default     = ""
+  description = "Password for the SSL certificate."
+}
+
 variable "app_auth" {
   type    = string
   default = "none"


### PR DESCRIPTION
 * Support for setting up Application Gateway when `var.expose_app` is true.
 * Optional support for WAF in the gateway when `var.waf` is true (and `var.expose_app` is true).
 * Refactor subnets so that each service is now isolated in its own subnet.

To do (future pull requests):
 - Support for custom domains. App Gateway is currently exposed only via an IP.
 - Relatedly, SSL support in the gateway is currently enabled via self-signed certificates that will not generally be trusted (by browsers, curl, etc). We should import support for trusted certificates on the custom domain.
 - Subnets need more granular network security rules.