### PR TITLE
Allow more OpenAI settings to be tuned via vars

### DIFF
--- a/terraform/openai.tf
+++ b/terraform/openai.tf
@@ -1,7 +1,7 @@
 resource "azurerm_cognitive_account" "openai" {
   name                  = format("%s-rbc-cs-oai", var.partner)
   resource_group_name   = azurerm_resource_group.main.name
-  location              = azurerm_resource_group.main.location
+  location              = local.openai_location
   sku_name              = "S0"
   kind                  = "OpenAI"
   tags                  = var.tags
@@ -50,7 +50,7 @@ resource "azurerm_cognitive_deployment" "llm" {
   }
   sku {
     name     = "Standard"
-    capacity = 80
+    capacity = var.openai_capacity
   }
   rai_policy_name        = var.disable_content_filter ? azapi_resource.no_content_filter[0].name : "Default"
   version_upgrade_option = "NoAutoUpgrade"

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -38,6 +38,18 @@ variable "location" {
   description = "Azure region to deploy to. Available options depend on the Azure environment."
 }
 
+variable "openai_location" {
+  type        = string
+  default     = null
+  nullable    = true
+  description = <<EOF
+Azure region to deploy the OpenAI cognitive service to. Available options depend on the Azure environment.
+
+By default, this is the same as the main location.
+Some models are not available in all regions, so the default location can be overridden as needed.
+EOF
+}
+
 variable "azure_env" {
   type        = string
   default     = "usgovernment"
@@ -149,8 +161,15 @@ for approval to disable filters. Once approved, re-deploy with this set to true.
 EOF
 }
 
+variable "openai_capacity" {
+  type        = number
+  default     = 80
+  description = "In thousands of tokens per minute."
+}
+
 locals {
-  is_gov_cloud  = var.azure_env == "usgovernment"
-  description   = "Whether this configuration uses Azure Government Cloud."
-  api_image_tag = format("%s/%s:%s", var.api_image_registry, var.api_image, var.api_image_version)
+  is_gov_cloud    = var.azure_env == "usgovernment"
+  description     = "Whether this configuration uses Azure Government Cloud."
+  api_image_tag   = format("%s/%s:%s", var.api_image_registry, var.api_image, var.api_image_version)
+  openai_location = var.openai_location != null ? var.openai_location : var.location
 }


### PR DESCRIPTION
 - Set token capacity via vars (since there may be a hard / variable limit on the subscription)
 - Allow OpenAI resource location to be set independent of other services, since not all models are available in all regions. (For example gpt-4o can't be deployed in usvirginia but can in usarizona.)