### PR TITLE
More networking options

### DIFF
--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -56,10 +56,12 @@ resource "azurerm_container_app" "main" {
   }
 
   ingress {
-    allow_insecure_connections = false
+    allow_insecure_connections = var.app_ingress_transport != "https"
     target_port                = 8000
-    external_enabled           = var.expose_app
-    transport                  = "http"
+    external_enabled           = true
+    # The allowed types are actually `http` and `tcp`, not `https`.
+    # To support `https`, we specify `http` here with insecure connections disallowed.
+    transport = var.app_ingress_transport == "https" ? "http" : var.app_ingress_transport
     traffic_weight {
       latest_revision = true
       percentage      = 100

--- a/terraform/net.tf
+++ b/terraform/net.tf
@@ -114,7 +114,6 @@ resource "azurerm_private_dns_zone" "app" {
 }
 
 resource "azurerm_private_dns_a_record" "app_wildcard" {
-  count               = var.expose_app ? 1 : 0
   name                = "*"
   zone_name           = azurerm_private_dns_zone.app.name
   resource_group_name = azurerm_resource_group.main.name
@@ -123,7 +122,6 @@ resource "azurerm_private_dns_a_record" "app_wildcard" {
 }
 
 resource "azurerm_private_dns_a_record" "app_exact" {
-  count               = var.expose_app ? 1 : 0
   name                = "@"
   zone_name           = azurerm_private_dns_zone.app.name
   resource_group_name = azurerm_resource_group.main.name
@@ -173,4 +171,13 @@ resource "azurerm_public_ip" "gateway" {
   location            = azurerm_resource_group.main.location
   allocation_method   = "Static"
   sku                 = "Standard"
+}
+
+resource "azurerm_virtual_network_peering" "app_to_cms" {
+  count                        = var.peered_network_id != null ? 1 : 0
+  name                         = format("%s-rbc-app-to-cms-peering", var.partner)
+  resource_group_name          = azurerm_resource_group.main.name
+  virtual_network_name         = azurerm_virtual_network.main.name
+  remote_virtual_network_id    = var.peered_network_id
+  allow_virtual_network_access = true
 }

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -59,13 +59,37 @@ variable "azure_env" {
 variable "expose_app" {
   type        = bool
   default     = true
-  description = "Expose the app outside of the app environment."
+  description = "Expose the app to the public internet."
 }
 
 variable "waf" {
   type        = bool
   default     = true
-  description = "Enable the Web Application Firewall for the application gateway."
+  description = <<EOF
+Enable the Web Application Firewall for the application gateway.
+
+This should be enabled if `expose_app` is true (and the app is exposed to the public internet).
+It will be ignored if the app is not exposed to the public internet.
+EOF
+}
+
+variable "peered_network_id" {
+  type        = string
+  nullable    = true
+  default     = null
+  description = "Make the app available to another virtual network via peering."
+}
+
+variable "app_ingress_transport" {
+  type        = string
+  default     = "https"
+  description = <<EOF
+Transport protocol for the app ingress. Must be 'http' or 'https' or 'tcp'.
+
+When set to `https`, the ingress will not accept insecure connections.
+
+When set to `tcp`, the ingress will accept TCP traffic on the container port (usually 8000).
+EOF
 }
 
 variable "ssl_cert_password" {


### PR DESCRIPTION
 - Allow peered vnet ID to be set
 - Always expose ingress for container app
 - Allow option for using tcp, http, or https in ingress
 - Always set DNS records for container app