### PR TITLE
Set default exposed port to null in ingress

### DIFF
--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -58,7 +58,7 @@ resource "azurerm_container_app" "main" {
   ingress {
     allow_insecure_connections = var.app_ingress_transport == "http"
     target_port                = 8000
-    exposed_port               = var.app_ingress_transport == "tcp" ? 8000 : var.app_ingress_transport == "http" ? 80 : 443
+    exposed_port               = var.app_ingress_transport == "tcp" ? 8000 : null
     external_enabled           = true
     # The allowed types are actually `http` and `tcp`, not `https`.
     # To support `https`, we specify `http` here with insecure connections disallowed.


### PR DESCRIPTION
Exposed port can't be set on ingress when type is not "tcp." Terraform should interpret "null" as a missing value instead of 0.