### PR TITLE
Option to enable toy mode

### DIFF
--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -15,6 +15,17 @@ variable "debug" {
   description = "Enable debug mode for the application."
 }
 
+variable "toy_mode" {
+  type        = bool
+  default     = false
+  description = <<EOF
+Enable demo mode for the application.
+
+This will disable the expensive features like OpenAI and Azure Form Recognizer,
+opting instead for fast and cheap (but low-quality) alternatives.
+EOF
+}
+
 variable "partner" {
   type        = string
   description = "Name of the group deploying this infrastructure. This is used for naming resources."


### PR DESCRIPTION
For internal / demo deployment of the API without wiring up to OpenAI / Form Recognizer to eliminate marginal costs.