### PR TITLE
Rewrite nfs to smb with custom mount

### DIFF
--- a/terraform/net.tf
+++ b/terraform/net.tf
@@ -88,6 +88,16 @@ resource "azurerm_subnet" "gateway-pl" {
   default_outbound_access_enabled               = true
 }
 
+resource "azurerm_subnet" "fs" {
+  count                                         = var.enable_research_env ? 1 : 0
+  name                                          = "fs"
+  resource_group_name                           = azurerm_resource_group.main.name
+  virtual_network_name                          = azurerm_virtual_network.main.name
+  address_prefixes                              = ["10.0.8.0/24"]
+  private_link_service_network_policies_enabled = true
+  default_outbound_access_enabled               = false
+}
+
 resource "azurerm_private_dns_zone" "openai" {
   name                = "privatelink.openai.azure.${local.is_gov_cloud ? "us" : "com"}"
   resource_group_name = azurerm_resource_group.main.name
@@ -105,6 +115,12 @@ resource "azurerm_private_dns_zone" "mssql" {
 
 resource "azurerm_private_dns_zone" "redis" {
   name                = "privatelink.redis.cache.${local.is_gov_cloud ? "usgovcloudapi.net" : "windows.net"}"
+  resource_group_name = azurerm_resource_group.main.name
+}
+
+resource "azurerm_private_dns_zone" "fs" {
+  count               = var.enable_research_env ? 1 : 0
+  name                = "privatelink.file.core.${local.is_gov_cloud ? "usgovcloudapi.net" : "windows.net"}"
   resource_group_name = azurerm_resource_group.main.name
 }
 
@@ -161,6 +177,14 @@ resource "azurerm_private_dns_zone_virtual_network_link" "redis" {
   name                  = format("%s-redis-dns-link", var.partner)
   resource_group_name   = azurerm_resource_group.main.name
   private_dns_zone_name = azurerm_private_dns_zone.redis.name
+  virtual_network_id    = azurerm_virtual_network.main.id
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "fs" {
+  count                 = var.enable_research_env ? 1 : 0
+  name                  = format("%s-fs-dns-link", var.partner)
+  resource_group_name   = azurerm_resource_group.main.name
+  private_dns_zone_name = azurerm_private_dns_zone.fs[0].name
   virtual_network_id    = azurerm_virtual_network.main.id
 }
 

--- a/terraform/research/start.sh
+++ b/terraform/research/start.sh
@@ -2,11 +2,36 @@
 
 set -e
 
-# If the directory /data exists, give it to the `rstudio` user
-echo "Checking for /data directory"
-if [ -d /data ]; then
-  echo "Found /data directory, giving it to rstudio user"
-  chown -R rstudio:rstudio /data
+# If the environment variable SMB_SHARE_URL is set, mount the SMB share
+echo "Checking for SMB mount..."
+if [ -n "$SMB_SHARE_URL" ]; then
+  echo "Mounting SMB share $SMB_SHARE_URL ..."
+
+  mkdir /mnt/datafs
+
+  # Create the credentials file
+  if [ ! -d "/etc/smbcredentials" ]; then
+    mkdir /etc/smbcredentials
+  fi
+  if [ ! -f "/etc/smbcredentials/datafs.cred" ]; then
+      echo "username=$SMB_USER" >> /etc/smbcredentials/datafs.cred
+      echo "password=$SMB_PASSWORD" >> /etc/smbcredentials/datafs.cred
+  fi
+  chmod 600 /etc/smbcredentials/datafs.cred
+
+  # Mount the share
+  echo "$SMB_SHARE_URL /mnt/datafs cifs nofail,credentials=/etc/smbcredentials/datafs.cred,dir_mode=0777,file_mode=0777,serverino,nosharesock,actimeo=30,noperm" >> /etc/fstab
+  mount -t cifs "$SMB_SHARE_URL" /mnt/datafs -o credentials=/etc/smbcredentials/datafs.cred,dir_mode=0777,file_mode=0777,serverino,nosharesock,actimeo=30,noperm
+
+  # Link the mount point to the configured path, or just "/data"
+  mount_point=${SMB_MOUNT_PATH:-/data}
+  ln -s /mnt/datafs $mount_point
+
+  # Ensure the mount point is writable for everyone
+  chmod 777 /mnt/datafs
+  chmod 777 $mount_point
+else
+  echo "SMB_SHARE_URL not set, skipping SMB mount."
 fi
 
 # Delegate to the real init script


### PR DESCRIPTION
NFS networking via container apps environment appears to be broken, still getting permissions errors. Another option is to keep using SMB but with custom mount options. Unfortunately, mount options are not supported in Terraform at this time and the azapi option requires a subsequent revision of the ACA app to be created (it also appeared to be broken / conflicting with the way terraform handles secrets).

I've verified that with the proper options, SMB _can_ be used with `git`. So trying to add a custom script to mount the file share manually when the container starts, with the provided environment variables.