### PR TITLE
Make allowed IP addresses for the WAF configurable

### DIFF
--- a/terraform/net.md
+++ b/terraform/net.md
@@ -47,7 +47,7 @@ We currently reserve a minimum of 184 addresses, as described below.
 | `*-rbc-gateway-ip` | N/A | ? | App Gateway public IP (not known until provisioned) |
 | `*-rbc-firewall-ip` | N/A | ? | Firewall public IP (not known until provisioned) |
 
-# Firewall
+# Outbound Firewall
 
 Outbound traffic for all subnets (excluding the Gateway, which is required to hop directly to the internet) is routed through the firewall.
 
@@ -63,3 +63,9 @@ blindchargingapi.eastus.data.azurecr.io
 Optionally, additional domains can be exempted by setting the `firewall_allowed_domains` variable.
 
 Note that it is necessary to exempt domains in order to use SAS signed links for redaction results.
+
+# Web Application Firewall
+
+When the app is exposed to the public internet, inbound traffic is controlled through the Web Application Firewall.
+
+By default, traffic is not filtered by IP. We recommend restricting traffic to specific IPs using the `var.allowed_ips` setting.

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -341,6 +341,19 @@ This is required if you want us to write redacted documents to blob storage.
 EOF
 }
 
+variable "allowed_ips" {
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+  description = <<EOF
+List of IP ranges to allow inbound traffic from.
+
+By default, all traffic is allowed.
+
+This is only relevant if the app is exposed to the public internet,
+and the WAF is enabled.
+EOF
+}
+
 locals {
   is_gov_cloud       = var.azure_env == "usgovernment"
   description        = "Whether this configuration uses Azure Government Cloud."


### PR DESCRIPTION
WAF can now be configured to restrict traffic to specific source IPs with the `allowed_ips` variable.