### PR TITLE
Move custom firewall fqdns to L7 so that we can accept wildcards

### DIFF
--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -365,6 +365,5 @@ locals {
     "blindchargingapi.azurecr.io",
     "azurecr.io",
   ]
-  firewall_allowed_domains = concat(var.firewall_allowed_domains, local.firewall_required_domains)
-  firewall_allow_outbound  = length(local.firewall_allowed_domains) > 0
+  firewall_custom_outbound = length(var.firewall_allowed_domains) > 0
 }


### PR DESCRIPTION
Small changes to outbound firewall rules in order to support wildcards.
 - Always create required outbound rules in the existing network rule collection
 - Create a separate custom application rule collection for custom domains. This is a layer 7 rule that support wildcards.

Existing deployments will need to recreate the default firewall rule upon their next deployment. Unfortunately this takes several minutes to do, even though we are not actually changing anything.