### PR TITLE
Fix status check transient errors

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3283,18 +3283,18 @@ files = [
 
 [[package]]
 name = "redis"
-version = "5.0.8"
+version = "5.2.1"
 description = "Python client for Redis database and key-value store"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "redis-5.0.8-py3-none-any.whl", hash = "sha256:56134ee08ea909106090934adc36f65c9bcbbaecea5b21ba704ba6fb561f8eb4"},
-    {file = "redis-5.0.8.tar.gz", hash = "sha256:0c5b10d387568dfe0698c6fad6615750c24170e548ca2deac10c649d463e9870"},
+    {file = "redis-5.2.1-py3-none-any.whl", hash = "sha256:ee7e1056b9aea0f04c6c2ed59452947f34c4940ee025f5dd83e6a6418b6989e4"},
+    {file = "redis-5.2.1.tar.gz", hash = "sha256:16f2e22dff21d5125e8481515e386711a34cbec50f0e44413dd7d9c060a54e0f"},
 ]
 
 [package.extras]
-hiredis = ["hiredis (>1.0.0)"]
-ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==20.0.1)", "requests (>=2.26.0)"]
+hiredis = ["hiredis (>=3.0.0)"]
+ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==23.2.1)", "requests (>=2.31.0)"]
 
 [[package]]
 name = "reportlab"
@@ -4263,4 +4263,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "0d2f72efc2c8184af351f13735ffe82aa2f48304f2b8dccaef57d8cec3c54c90"
+content-hash = "6a9766fcecf2c9f1440dec47780e11024f1e639ff7011eacec4368b6b934e680"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ aiosqlite = "^0.20.0"
 alligater = {git = "git@github.com:stanford-policylab/alligater.git"}
 nameparser = "^1.1.3"
 celery = "^5.4.0"
-redis = "^5.0.7"
+redis = "^5.2.1"
 azure-storage-blob = "^12.20.0"
 urllib3 = "2.2.3"
 pytz = "2024.2"


### PR DESCRIPTION
Status check on Azure returns "error" occasionally when there is an expired connection to a worker that's reused for `ping`. This seems to be a known issue and doesn't seem to actually impact the usability of the queue.

The status check will now try to check status up to two times and report "healthy" with a warning if we hit this issue on the first request.

There may be a better fix, such as purging the bad connections before trying to test. If the "warning" gets too obnoxious at some point in the future we can fix this.

Also bumps the version of the redis python client to pick up other bug fixes (perhaps even one that will mitigate this issue).