### PR TITLE
Private networking for Azure Monitor

### DIFF
--- a/terraform/monitor.tf
+++ b/terraform/monitor.tf
@@ -17,8 +17,9 @@ resource "azurerm_application_insights" "main" {
 }
 
 resource "azurerm_monitor_private_link_scope" "main" {
-  name                = lower(format("%s-ampls", local.application_insights_name))
-  resource_group_name = azurerm_resource_group.main.name
+  name                  = lower(format("%s-ampls", local.application_insights_name))
+  resource_group_name   = azurerm_resource_group.main.name
+  ingestion_access_mode = "PrivateOnly"
 }
 
 resource "azurerm_monitor_private_link_scoped_service" "main" {
@@ -37,7 +38,7 @@ resource "azurerm_private_endpoint" "monitor" {
 
   private_service_connection {
     name                           = "monitor-psc"
-    private_connection_resource_id = azurerm_monitor_private_link_scoped_service.main.id
+    private_connection_resource_id = azurerm_monitor_private_link_scope.main.id
     subresource_names              = ["azuremonitor"]
     is_manual_connection           = false
   }

--- a/terraform/monitor.tf
+++ b/terraform/monitor.tf
@@ -8,11 +8,42 @@ resource "azurerm_log_analytics_workspace" "main" {
 }
 
 resource "azurerm_application_insights" "main" {
-  # TODO(jnu): add app support for metrics instrumentation in config
   name                = local.application_insights_name
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
   application_type    = "web"
   workspace_id        = azurerm_log_analytics_workspace.main.id
   tags                = var.tags
+}
+
+resource "azurerm_monitor_private_link_scope" "main" {
+  name                = lower(format("%s-ampls", local.application_insights_name))
+  resource_group_name = azurerm_resource_group.main.name
+}
+
+resource "azurerm_monitor_private_link_scoped_service" "main" {
+  name                = lower(format("%s-amplsservice", local.application_insights_name))
+  resource_group_name = azurerm_resource_group.main.name
+  scope_name          = azurerm_monitor_private_link_scope.main.name
+  linked_resource_id  = azurerm_application_insights.main.id
+}
+
+resource "azurerm_private_endpoint" "monitor" {
+  name                = local.monitor_private_endpoint_name
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  subnet_id           = azurerm_subnet.monitor.id
+  tags                = var.tags
+
+  private_service_connection {
+    name                           = "monitor-psc"
+    private_connection_resource_id = azurerm_monitor_private_link_scoped_service.main.id
+    subresource_names              = ["azuremonitor"]
+    is_manual_connection           = false
+  }
+
+  private_dns_zone_group {
+    name                 = "pdz-monitor"
+    private_dns_zone_ids = [azurerm_private_dns_zone.monitor.id]
+  }
 }

--- a/terraform/names_vars.tf
+++ b/terraform/names_vars.tf
@@ -86,6 +86,12 @@ variable "application_insights_name" {
   description = "Name of the Application Insights resource."
 }
 
+variable "monitor_private_endpoint_name" {
+  type        = string
+  default     = ""
+  description = "Name of the Monitor Private Endpoint resource."
+}
+
 variable "virtual_network_name" {
   type        = string
   default     = ""
@@ -132,6 +138,12 @@ variable "gateway_subnet_name" {
   type        = string
   default     = "gateway"
   description = "Name of the gateway subnet."
+}
+
+variable "monitor_subnet_name" {
+  type        = string
+  default     = "monitor"
+  description = "Name of the monitor subnet."
 }
 
 variable "gateway_private_link_subnet_name" {
@@ -221,6 +233,7 @@ locals {
   private_link_configuration_name       = coalesce(var.app_gateway_private_link_configuration_name, lower(format("%s-app-gw-plc", local.name_prefix)))
   log_analytics_workspace_name          = coalesce(var.log_analytics_workspace_name, lower(format("%s-law", local.name_prefix)))
   application_insights_name             = coalesce(var.application_insights_name, lower(format("%s-mon-insights", local.name_prefix)))
+  monitor_private_endpoint_name         = coalesce(var.monitor_private_endpoint_name, lower(format("%s-mon-pe", local.name_prefix)))
   virtual_network_name                  = coalesce(var.virtual_network_name, lower(format("%s-vnet", local.name_prefix)))
   openai_account_name                   = coalesce(var.openai_account_name, lower(format("%s-cs-oai", local.name_prefix)))
   openai_llm_deployment_name            = coalesce(var.openai_llm_deployment_name, lower(format("%s-oai-llm", local.name_prefix)))

--- a/terraform/net.md
+++ b/terraform/net.md
@@ -34,6 +34,7 @@ We currently reserve a minimum of 184 addresses, as described below.
 | `gateway-pl` | `10.0.7.0/24` | `/29` | App Gateway private link |
 | `fs` | `10.0.8.0/24` | `/27` | File service private endpoint (for research environment persistent storage) |
 | `AzureFirewallSubnet`* | `10.0.9.0/24` | `/26` | Firewall for outbound traffic |
+| `monitor` | `10.0.10.0/24` | `/29` | Azure Monitor private endpoint |
 
 `*` Note the name of the firewall subnet is required by Azure and is not configurable.
 

--- a/terraform/net.tf
+++ b/terraform/net.tf
@@ -107,6 +107,15 @@ resource "azurerm_subnet" "firewall" {
   default_outbound_access_enabled               = false
 }
 
+resource "azurerm_subnet" "monitor" {
+  name                                          = var.monitor_subnet_name
+  resource_group_name                           = azurerm_resource_group.main.name
+  virtual_network_name                          = azurerm_virtual_network.main.name
+  address_prefixes                              = var.monitor_subnet_address_space
+  private_link_service_network_policies_enabled = true
+  default_outbound_access_enabled               = false
+}
+
 resource "azurerm_private_dns_zone" "openai" {
   name                = "privatelink.openai.azure.${local.is_gov_cloud ? "us" : "com"}"
   resource_group_name = azurerm_resource_group.main.name
@@ -127,6 +136,12 @@ resource "azurerm_private_dns_zone" "mssql" {
 
 resource "azurerm_private_dns_zone" "redis" {
   name                = "privatelink.redis.cache.${local.is_gov_cloud ? "usgovcloudapi.net" : "windows.net"}"
+  resource_group_name = azurerm_resource_group.main.name
+  tags                = var.tags
+}
+
+resource "azurerm_private_dns_zone" "monitor" {
+  name                = "privatelink.monitor.azure.${local.is_gov_cloud ? "us" : "com"}"
   resource_group_name = azurerm_resource_group.main.name
   tags                = var.tags
 }
@@ -207,6 +222,14 @@ resource "azurerm_private_dns_zone_virtual_network_link" "fs" {
   name                  = format("%s-fs-dns-link", local.name_prefix)
   resource_group_name   = azurerm_resource_group.main.name
   private_dns_zone_name = azurerm_private_dns_zone.fs[0].name
+  virtual_network_id    = azurerm_virtual_network.main.id
+  tags                  = var.tags
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "monitor" {
+  name                  = format("%s-monitor-dns-link", local.name_prefix)
+  resource_group_name   = azurerm_resource_group.main.name
+  private_dns_zone_name = azurerm_private_dns_zone.monitor.name
   virtual_network_id    = azurerm_virtual_network.main.id
   tags                  = var.tags
 }

--- a/terraform/net_vars.tf
+++ b/terraform/net_vars.tf
@@ -73,3 +73,9 @@ variable "firewall_subnet_address_space" {
   default     = ["10.0.9.0/24"]
   description = "Firewall subnet address space."
 }
+
+variable "monitor_subnet_address_space" {
+  type        = list(string)
+  default     = ["10.0.10.0/24"]
+  description = "Monitor subnet address space."
+}


### PR DESCRIPTION
Fixes an issue with metrics collection. PrivateLink was not configured for the Azure Monitor service, and the outbound firewall was also not configured to let the metrics collector reach the Azure Monitor service. This resulted in metric data failing to reach the Monitor service, so no data on app performance has been collected since the outbound firewall restrictions were put in place. Further, the fail/retry disk cache that the local metrics collector uses was filled and spewing out lots of warnings and cluttering the logs, ironically making debugging even harder.

Fixed by setting up private networking for the Monitor. This is a little more complicated than other services. It requires a private endpoint deployment in a new subnet and additionally setting up a private link scoped service for the monitor.

Luckily, Azure appears to adapt to the private link networking automatically and not require changing the connection string used to connect to the Monitor service.

This PR adds an additional security restriction that metrics _must_ be ingested over PrivateLink.

---

All partners should apply this patch ASAP in case we need to debug something. Having the metrics properly logged and the console logs cleaner will help tremendously.

Instructions for upgrading are:

1. Connect to cloud shell where you previously ran deployments
2. Navigate to the terraform directory, e.g. `cd blind-charging-api/terraform`
3. Run `git pull` to fetch the latest updates
4. Run an upgrade, e.g `terraform apply -var-file="../../<my-site>.tfvars"` (replacing `<my-site>` with the appropriate file name).
5. Review the proposed changes -- should be some new networking items related to monitor.
6. Type "yes" and wait for the updates to complete.