### PR TITLE
Add app config, terraform config, and cli option for number of concurrent workers

### DIFF
--- a/app/server/config.py
+++ b/app/server/config.py
@@ -95,6 +95,7 @@ class QueueConfig(BaseModel):
     task: TaskConfig = TaskConfig()
     store: StoreConfig = RedisConfig()
     broker: BrokerConfig = RedisConfig()
+    concurrency: int = 10
 
 
 class ExperimentsConfig(BaseModel):

--- a/terraform/app_config.tf
+++ b/terraform/app_config.tf
@@ -68,6 +68,8 @@ connection_string = "${azurerm_application_insights.main.connection_string}"
 
 [queue]
 
+concurrency = ${var.worker_threads}
+
 [queue.store]
 engine = "redis"
 host = "${local.redis_fqdn}"

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -353,6 +353,14 @@ and the WAF is enabled.
 EOF
 }
 
+variable "worker_threads" {
+  type        = number
+  default     = 10
+  description = <<EOF
+Number of concurrent workers to use in a process for processing requests.
+EOF
+}
+
 locals {
   is_gov_cloud       = var.azure_env == "usgovernment"
   description        = "Whether this configuration uses Azure Government Cloud."


### PR DESCRIPTION
Terraform var: `worker_threads: int = 10`
CLI option: `concurrency: int | None = None`
App Config option: `queue.concurrency: int = 10`

This lets the number of celery workers in a process be controlled in `tfvars` and elsewhere.

CLI option takes precedence, config option is secondary.