### PR TITLE
Use kombu serializer for status page

### DIFF
--- a/app/server/meta.py
+++ b/app/server/meta.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 import platform
@@ -7,6 +6,7 @@ from dataclasses import asdict, dataclass
 from datetime import datetime
 from typing import TypedDict
 
+import kombu.utils.json as json
 import psutil
 import tomllib
 import yaml


### PR DESCRIPTION
Fixes an error showing scheduled tasks which require custom type serialization as configured in the app through `kombu`. So the default `json` library hits an error.