### PR TITLE
Set recommended Redis capacity SKU to Standard-C4

### DIFF
--- a/terraform/redis.tf
+++ b/terraform/redis.tf
@@ -2,7 +2,7 @@ resource "azurerm_redis_cache" "main" {
   name                 = local.redis_cache_name
   resource_group_name  = azurerm_resource_group.main.name
   location             = azurerm_resource_group.main.location
-  capacity             = 3
+  capacity             = var.redis_capacity_sku
   family               = "C"
   sku_name             = "Standard"
   non_ssl_port_enabled = false

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -361,6 +361,18 @@ Number of concurrent workers to use in a process for processing requests.
 EOF
 }
 
+variable "redis_capacity_sku" {
+  type        = number
+  default     = 4
+  description = <<EOF
+SKU of Azure Redis Cache Standard to use for deployment.
+
+We currently recommend C4 as a nice balance of memory and cost.
+
+https://azure.microsoft.com/en-us/pricing/details/cache/
+EOF
+}
+
 locals {
   is_gov_cloud       = var.azure_env == "usgovernment"
   description        = "Whether this configuration uses Azure Government Cloud."


### PR DESCRIPTION
The current default of Standard-C3 is not significantly cheaper than Standard-C4, while C4 offers 2x memory which will give even larger deployments quite a large amount of headroom. This will also make the idea of extending the retention period on the results store less concerning.

The tradeoff with C4 vs. C3 (i.e., the reason it is similarly priced) is that it offers reduced network capacity. This is not expected to be a bottleneck in our application, so it's an easy tradeoff to make.