### PR TITLE
Make queue store retention time configurable per deployment

### DIFF
--- a/app/server/config.py
+++ b/app/server/config.py
@@ -23,8 +23,12 @@ from .store import RedisConfig, RedisTestConfig
 logger = logging.getLogger(__name__)
 
 
+FOUR_HOURS_S = 4 * 60 * 60
+"""Four hours in seconds."""
+
+
 class TaskConfig(BaseModel):
-    retention_hours: float = 72.0
+    retention_time_seconds: int = FOUR_HOURS_S
     max_retries: int = 3
     retry_interval: float = 60.0
     callback_timeout_seconds: float = 30.0

--- a/terraform/app_config.tf
+++ b/terraform/app_config.tf
@@ -70,6 +70,9 @@ connection_string = "${azurerm_application_insights.main.connection_string}"
 
 concurrency = ${var.worker_threads}
 
+[queue.task]
+retention_time_seconds = ${var.queue_store_retention}
+
 [queue.store]
 engine = "redis"
 host = "${local.redis_fqdn}"

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -373,6 +373,17 @@ https://azure.microsoft.com/en-us/pricing/details/cache/
 EOF
 }
 
+variable "queue_store_retention" {
+  type        = number
+  default     = 14400
+  description = <<EOF
+Number of seconds to retain data in the queue results store.
+
+Default is 4 hours.
+EOF
+}
+
+
 locals {
   is_gov_cloud       = var.azure_env == "usgovernment"
   description        = "Whether this configuration uses Azure Government Cloud."


### PR DESCRIPTION
honors existing retention time variable, allows it to be set from in the tfvars terraform config to customize retention time for a specific deployment