### PR TITLE
Allow passing flags from tfvars

### DIFF
--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -91,6 +91,14 @@ resource "azurerm_container_app" "main" {
         name  = "CONFIG_PATH"
         value = "/secrets/app-config"
       }
+
+      dynamic "env" {
+        for_each = var.api_flags
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
     }
 
     container {
@@ -107,6 +115,15 @@ resource "azurerm_container_app" "main" {
         name  = "CONFIG_PATH"
         value = "/secrets/app-config"
       }
+
+      dynamic "env" {
+        for_each = var.api_flags
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
+
       liveness_probe {
         host             = "127.0.0.1"
         path             = "/api/v1/health"
@@ -131,6 +148,15 @@ resource "azurerm_container_app" "main" {
         name  = "CONFIG_PATH"
         value = "/secrets/app-config"
       }
+
+      dynamic "env" {
+        for_each = var.api_flags
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
+
       liveness_probe {
         host                    = "127.0.0.1"
         path                    = "/health"

--- a/terraform/app_config.tf
+++ b/terraform/app_config.tf
@@ -52,10 +52,6 @@ api_version = "2024-06-01"
 method = "chat"
 model = "${azurerm_cognitive_deployment.llm.name}"
 system = { prompt_id = "redact" }
-
-[processor.pipe.resolver]
-model = "${azurerm_cognitive_deployment.llm.name}"
-system = { prompt_id = "resolver" }
 EOF
 
   # Full application config file

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -383,6 +383,14 @@ Default is 4 hours.
 EOF
 }
 
+variable "api_flags" {
+  type        = map(string)
+  default     = {}
+  description = <<EOF
+Environment variables to pass to the API and worker containers.
+EOF
+}
+
 
 locals {
   is_gov_cloud       = var.azure_env == "usgovernment"


### PR DESCRIPTION
Set env flags for the containers from tfvars.

This will allow us to control experimental features for different deployments more easily.