### PR TITLE
Add `odbc` to list of installed R packages

### DIFF
--- a/terraform/research/Dockerfile
+++ b/terraform/research/Dockerfile
@@ -44,6 +44,7 @@ RUN install2.r --error --skipmissing --skipinstalled -n $(nproc --all) \
     grid \
     janitor \
     jsonlite \
+    odbc \
     parallel \
     png \
     purrr \


### PR DESCRIPTION
Simply add a single R package, `odbc`, to be pre-installed on research images. `odbc` facilitates connection with SQL databases in R.