### PR TITLE
Clean up request logging

### DIFF
--- a/app/server/config.py
+++ b/app/server/config.py
@@ -17,6 +17,7 @@ from pydantic_settings import BaseSettings
 from .authn import AuthnConfig, NoAuthnConfig
 from .db import RdbmsConfig
 from .lazy import LazyObjectProxy
+from .log_util import improve_uvicorn_access_logs
 from .metrics import AzureMonitorMetricsConfig, NoMetricsConfig
 from .store import RedisConfig, RedisTestConfig
 
@@ -168,3 +169,6 @@ for name in _logger_names:
             break
     else:
         logging.getLogger(name).setLevel(logging.WARNING)
+
+# Apply some custom filtering to uvicorn's logs.
+improve_uvicorn_access_logs()

--- a/app/server/log_util.py
+++ b/app/server/log_util.py
@@ -1,0 +1,60 @@
+import logging
+from typing import cast
+
+_UvicornLogRecordArgs = tuple[str, str, str, str, int]
+"""Type of the args that are passed to the uvicorn.access log.
+
+Tuple fields:
+ - Host
+ - Method
+ - Path
+ - HTTP Version
+ - Status
+"""
+
+
+class _UvicornAccessLogFilter(logging.Filter):
+    """Filter access log messages."""
+
+    def __init__(self, logger: logging.Logger):
+        self._logger = logger
+
+    @property
+    def _current_level(self) -> int:
+        return self._logger.level
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Adjust log level based on message type.
+
+        Health check logs should go to debug,
+        4xx errors should go to warning,
+        5xx errors should go to error.
+        """
+        args = cast(_UvicornLogRecordArgs, record.args)
+        path, status = args[2], args[4]
+        if path == "/api/v1/health" and status == 200:
+            record.levelname = "DEBUG"
+            record.levelno = logging.DEBUG
+        if status >= 400:
+            record.levelname = "WARNING"
+            record.levelno = logging.WARNING
+        if status >= 500:
+            record.levelname = "ERROR"
+            record.levelno = logging.ERROR
+
+        # Check if we should filter this based on logger's current level.
+        if record.levelno < self._current_level:
+            return False
+
+        return True
+
+
+def improve_uvicorn_access_logs():
+    """Configure the uvicorn access log to be more useful.
+
+    Specifically, this adjusts the level of messages based on the content.
+    When debug mode is turned off, this will have the effect of hiding the
+    health check logs when the service is healthy.
+    """
+    uv_logger = logging.getLogger("uvicorn.access")
+    uv_logger.addFilter(_UvicornAccessLogFilter(uv_logger))


### PR DESCRIPTION
 - Remove custom logging middleware since it's mostly redundant with uvicorn's access log
 - This does lose log timing, but that itself is redundant with other metrics that the app has been instrumented with
 - Add a filter to condition access log level based on message. Successful health checks are moved to debug (so will be hidden with `config.debug = false`), while 4xx errors are logged as warnings, and 5xx errors are logged as errors.
 - Clean up a few instances of `warning` being used where `info` is better.