### PR TITLE
Reject redactions based on quality

### DIFF
--- a/app/server/config.py
+++ b/app/server/config.py
@@ -6,6 +6,7 @@ from typing import Annotated, Union
 import tomllib
 from bc2.core.pipeline import (
     ExtractConfig,
+    InspectConfig,
     ParseConfig,
     RedactConfig,
     RenderConfig,
@@ -44,7 +45,7 @@ MetricsConfig = Union[AzureMonitorMetricsConfig, NoMetricsConfig]
 
 
 AnyPipelineProcessingConfig = Union[
-    ExtractConfig, ParseConfig, RedactConfig, RenderConfig
+    ExtractConfig, ParseConfig, RedactConfig, RenderConfig, InspectConfig
 ]
 
 

--- a/app/server/config.py
+++ b/app/server/config.py
@@ -111,6 +111,20 @@ class ExperimentsConfig(BaseModel):
     config_reload_interval: float = 30.0
 
 
+class RedactionParamsConfig(BaseModel):
+    """Configuration for redaction parameters."""
+
+    # Reject redactions based on the frequency of errors that appear to be
+    # hallucinations instead of valid redactions. We can't measure this
+    # perfectly, but it tends to be fairly obvious when the model goes off
+    # while trying to redact something.
+    #
+    # It's useful to keep this above 0 since the model can introduce some
+    # corrections to the underlying text that are reasonable, and we can let
+    # these slide.
+    max_redaction_error_rate: float = 0.002
+
+
 class Config(BaseSettings):
     debug: bool = False
     queue: QueueConfig = QueueConfig()
@@ -118,6 +132,7 @@ class Config(BaseSettings):
     metrics: MetricsConfig = NoMetricsConfig()
     authentication: AuthnConfig = NoAuthnConfig()
     processor: ProcessorConfig
+    params: RedactionParamsConfig = RedactionParamsConfig()
 
 
 def _load_config(path: str = os.getenv("CONFIG_PATH", "config.toml")) -> Config:

--- a/app/server/tasks/redact.py
+++ b/app/server/tasks/redact.py
@@ -121,7 +121,8 @@ def redact(
         )
 
         if ctx.quality:
-            check_quality(ctx.quality)
+            p_valid = 1 - config.params.max_redaction_error_rate
+            check_quality(ctx.quality, p_valid=p_valid)
 
         # Inspect every annotation and merge it into the shared store.
         if ctx.annotations:

--- a/config.toml
+++ b/config.toml
@@ -45,4 +45,5 @@ path = "test.db"
 pipe = [
     { engine = "extract:tesseract" },
     { engine = "redact:noop", delimiters = ["[", "]"] },
+    { engine = "inspect:quality" },
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -497,7 +497,7 @@ aio = ["azure-core[aio] (>=1.30.0)"]
 
 [[package]]
 name = "bc2"
-version = "0.6.1"
+version = "0.6.2"
 description = ""
 optional = false
 python-versions = "^3.10"
@@ -527,7 +527,7 @@ typer = "0.12.5"
 type = "git"
 url = "git@github.com:stanford-policylab/bc2.git"
 reference = "HEAD"
-resolved_reference = "11bf1e029945128e11fffb545d45b58e50b730eb"
+resolved_reference = "565cd831c2cb70ef1a036b18c8e7b6f9a2cdf767"
 
 [[package]]
 name = "billiard"

--- a/terraform/app_config.tf
+++ b/terraform/app_config.tf
@@ -61,6 +61,10 @@ api_version = "2024-06-01"
 method = "chat"
 model = "${azurerm_cognitive_deployment.llm.name}"
 system = { prompt_id = "redact" }
+
+[[processor.pipe]]
+# 4) Inspector for debugging
+engine = "inspect:quality"
 EOF
 
   # Full application config file


### PR DESCRIPTION
 - Add new redaction quality metrics to pipeline
 - Set a configurable max error rate for the pipeline
 - Reject redactions when we measure a character error rate higher than the set maximum

Rejected redactions will be retried per the normal retry policy. When we reach the maximum number of retries we will fail the redaction task and set the document status to failed, with the `LowQuality` error as the descriptor of the failure.

In the event that we fail to generate a high quality redaction, the client can either re-submit the job to try again or bypass blind review for this document.

## Future work

 - Retries may want to adjust parameters for the redaction request to try to avoid hallucinations, either with a refined prompt or reduced entropy or both.
 - The specific threshold set in this PR is just a guess about what might be useful. We want to pick a threshold such that some minor hallucinations that correct things like grammar and punctuation are tolerated, while blatant hallucinations are caught and discarded. Currently we reject documents with a character error rate of 1 in 200 characters, which is fairly generous. We can compute more sophisticated metrics that consider the actual invalid segments individually and do a more thorough vetting of the errors.