### PR TITLE
Rewrite terraform app config to be chunk-aware

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blind-charging-api"
-version = "0.11.3"
+version = "0.12.0"
 description = "Race-blind Charging API"
 authors = ["Joe Nudell <jnudell@hks.harvard.edu>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blind-charging-api"
-version = "0.12.0"
+version = "0.12.0-alpha.0"
 description = "Race-blind Charging API"
 authors = ["Joe Nudell <jnudell@hks.harvard.edu>"]
 readme = "README.md"

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -470,6 +470,26 @@ Environment variables to pass to the API and worker containers.
 EOF
 }
 
+variable "parse_chunks_max_iterations" {
+  type        = number
+  default     = 5
+  description = <<EOF
+Maximum number of iterations to run the parser.
+
+This may be necessary to work around output token limits for LLM parsing.
+EOF
+}
+
+variable "redact_chunks_max_iterations" {
+  type        = number
+  default     = 5
+  description = <<EOF
+Maximum number of iterations to run the redactor.
+
+This may be necessary to work around output token limits for LLM redaction.
+EOF
+}
+
 
 locals {
   is_gov_cloud       = var.azure_env == "usgovernment"


### PR DESCRIPTION
Rewrites the app config in Terraform to account for output window constraints in the parse and redact/inspect steps and apply a limited amount of iteration when truncation is detected.

By default the config will attempt up to 5 iterations to complete the specified task. This limit can be increased by editing the `{redact,parse}_chunks_max_iterations` variables in the Terraform variables file.

Since this PR relies on the rewritten experimental chunking support that's been available in the app for several weeks, deploying this new Terraform change should not result in any new functions. There will, however, be a regression (turning chunking support off) if a new API image is deployed _without_ running the terraform update.