### PR TITLE
Unstable/stable release channels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     outputs:
       api_release: ${{ steps.api.outputs.release }}
       api_version: ${{ steps.api.outputs.version }}
+      api_release_channel: ${{ steps.api.outputs.channel }}
+      api_latest: ${{ steps.api.outputs.latest }}
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -35,6 +37,17 @@ jobs:
         run: |
           API_VERSION=$(cat pyproject.toml | grep '^version' | awk '{print$3}' | sed 's/"//g')
           echo "version=$API_VERSION" >> "$GITHUB_OUTPUT"
+
+          # Choose between "unstable" and "stable" channels.
+          # We choose "unstable" when the version contains a hyphen (e.g., 0.1.0-alpha).
+          # TODO(jnu): "latest" is an alias for "stable" right now.
+          # It's deprecated and should be replaced with "stable" in the future.
+          if [[ $API_VERSION == *"-"* ]]; then
+            echo "channel=unstable" >> "$GITHUB_OUTPUT"
+          else
+            echo "channel=stable" >> "$GITHUB_OUTPUT"
+            echo "latest=true" >> "$GITHUB_OUTPUT"
+          fi
 
           if git rev-parse "api-$API_VERSION" >/dev/null 2>&1; then
             echo "Tag api-$API_VERSION already exists"
@@ -124,9 +137,11 @@ jobs:
           # Override default context to use the checkout with Dockerfile modifications.
           context: ${{github.workspace}}
           file: ${{github.workspace}}/Dockerfile
-          # Apply new version tag and replace any existing `latest` tag.
+          # Apply new version tag, as well as a tag based on release channel.
+          # TODO(jnu): "latest" is an alias for "stable" right now, but it's deprecated
+          # and will be removed in the future.
           push: true
-          tags: blindchargingapi.azurecr.io/blind-charging-api:latest,blindchargingapi.azurecr.io/blind-charging-api:${{ needs.tag.outputs.api_version }}
+          tags: blindchargingapi.azurecr.io/blind-charging-api:${{ needs.tag.outputs.api_release_channel }},blindchargingapi.azurecr.io/blind-charging-api:${{ needs.tag.outputs.api_version }}${{ needs.tag.outputs.api_latest == 'true' && ',blindchargingapi.azurecr.io/blind-charging-api:latest' || '' }}
 
   # Create GitHub release with notes
   release:
@@ -145,8 +160,8 @@ jobs:
         with:
           name: v${{ needs.tag.outputs.api_version }}
           tag_name: api-${{ needs.tag.outputs.api_version }}
-          prerelease: false
-          make_latest: true
+          prerelease: ${{ needs.tag.outputs.api_release_channel == 'unstable' }}
+          make_latest: ${{ needs.tag.outputs.api_release_channel == 'stable' }}
           generate_release_notes: true
 
       - name: Post Slack message

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -212,13 +212,13 @@ variable "api_image" {
 
 variable "api_image_version" {
   type        = string
-  default     = "latest"
+  default     = "stable"
   description = <<EOF
 The version of the Docker image used to run the API.
 
 This version must exist in the repo specified in `var.api_image`.
 
-**WARNING** If the tag is `latest` (the default!), the image version may upgrade
+**WARNING** If the tag is `stable` (the default!), the image version may upgrade
 unexpectedly when the app containers restart. This is usually fine, but it's
 recommended to lock the version and increment it manually in case a new image
 contains incompatible changes.


### PR DESCRIPTION
 - Adds `unstable` auto-release channel for easier image testing in the staging environment
 - Adds `stable` auto-release channel for tested releases in production
 - Deprecates `latest` auto-release channel which is too vague about whether the code has actually been tested or not 😅 