### PR TITLE
Enable embedding always

### DIFF
--- a/terraform/app_config.tf
+++ b/terraform/app_config.tf
@@ -17,8 +17,8 @@ host = "${local.mssql_fqdn}"
 database = "${azurerm_mssql_database.main.name}"
 EOF
 
-  # Add an embedding configuration when the research environment is enabled.
-  embedding_config = !var.enable_research_env ? "" : <<EOF
+  # Config for embedding model
+  embedding_config = <<EOF
 [experiments.embedding]
 [experiments.embedding.client]
 azure_endpoint = "${local.openai_endpoint}"


### PR DESCRIPTION
When turned on, embedding (compute + storage) accounts for a small fraction of one percent of all inference costs. Considering the fixed infrastructure costs as well, the cost of embedding is a negligible cost. So we will now always compute embeddings for all documents submitted for redaction, whether we currently need it or not. This will give us more information if we need it in the future, with really no downside even if we never need them.