### PR TITLE
Improve error handling

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -497,7 +497,7 @@ aio = ["azure-core[aio] (>=1.30.0)"]
 
 [[package]]
 name = "bc2"
-version = "0.7.1"
+version = "0.7.2"
 description = "Race-blind charging redaction libary."
 optional = false
 python-versions = "^3.10"
@@ -528,7 +528,7 @@ typer = "0.12.5"
 type = "git"
 url = "git@github.com:stanford-policylab/bc2.git"
 reference = "HEAD"
-resolved_reference = "0b3bf9126a6f1179a2d5740d90cb008c3b018979"
+resolved_reference = "20039f109fa06bcb087fc7f9f1ae99dc5ca2a0be"
 
 [[package]]
 name = "billiard"

--- a/tests/unit/test_redact.py
+++ b/tests/unit/test_redact.py
@@ -2,6 +2,7 @@ import pathlib
 import re
 from typing import cast
 
+from bc2.core.inspect.quality import QualityReport
 from fakeredis import FakeRedis
 
 from app.server.generated.models import OutputFormat
@@ -12,6 +13,7 @@ from app.server.tasks import (
     RedactionTaskResult,
     redact,
 )
+from app.server.tasks.redact import check_quality
 
 this_dir = pathlib.Path(__file__).parent
 sample_data_dir = this_dir.parent.parent / "app" / "server" / "sample_data"
@@ -111,3 +113,10 @@ def test_redact_new_errors(fake_redis_store: FakeRedis):
             renderer=OutputFormat.PDF,
         ).model_dump()
     )
+
+
+def test_check_quality_divide_by_zero():
+    # Test case where the denominator is zero.
+    # Don't raise an error!
+    qr = QualityReport()
+    assert check_quality(qr) is None


### PR DESCRIPTION
 - Handles an edge case where quality report raises divide-by-zero error when redaction is empty. We will avoid the zero-div error, so that the upstream error that triggered this condition can be surfaced better.
 - Add more exception handling over code blocks that don't perform critical routines, to help minimize number of scenarios where redaction completely breaks and must be retried.
 - Bump `bc2` version to pick up changes along the same lines in the pipeline processor