### PR TITLE
Better error handling for content filtering

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -497,7 +497,7 @@ aio = ["azure-core[aio] (>=1.30.0)"]
 
 [[package]]
 name = "bc2"
-version = "0.7.3"
+version = "0.7.4"
 description = "Race-blind charging redaction libary."
 optional = false
 python-versions = "^3.10"
@@ -528,7 +528,7 @@ typer = "0.12.5"
 type = "git"
 url = "git@github.com:stanford-policylab/bc2.git"
 reference = "HEAD"
-resolved_reference = "38119aedf242899a30d9626f7e28eb8d3175fc2b"
+resolved_reference = "cdf796fc67e81698889e3c0484dbdd17c7e355b6"
 
 [[package]]
 name = "billiard"


### PR DESCRIPTION
Bumps `bc2` version to pick up a change to throw an explicit error when we notice that a content filter has been applied by OpenAI. We will now abort the processing pipeline and return a `FilteredContentError` with instructions to adjust the content moderation settings when this occurs anywhere in the pipeline.