### PR TITLE
Permit missing gater config

### DIFF
--- a/app/server/features.py
+++ b/app/server/features.py
@@ -108,7 +108,12 @@ def _load_config_from_db() -> str:
 
     with session.begin() as tx:
         try:
-            gater = tx.query(Gater).where(Gater.active).one()
+            gater = tx.query(Gater).where(Gater.active).one_or_none()
+            if not gater:
+                logger.debug(
+                    "No active alligater config found in database, using empty"
+                )
+                return ""
             return gater.blob
         except Exception as e:
             logger.error(f"Failed to fetch alligater config: {e}")


### PR DESCRIPTION
Tone done errors from when `alligater` is not configured. This is expected in the default configuration. Reserve error logging for true connectivity errors, tone done missing config to a debug-level log.