### PR TITLE
Use memory more responsibly on base64 attachment type

### DIFF
--- a/app/server/case_helper.py
+++ b/app/server/case_helper.py
@@ -30,6 +30,20 @@ def get_document_sync(file_storage_id: str | None) -> bytes:
     return asyncio.run(_get())
 
 
+async def save_document(file_bytes: bytes) -> str:
+    """Save a document blob in the queue's store.
+
+    Args:
+        file_bytes: Content to save.
+
+    Returns:
+        ID in the store where the content was saved.
+    """
+    async with config.queue.store.driver() as store:
+        async with store.tx() as tx:
+            return await CaseStore.save_blob(tx, file_bytes)
+
+
 def save_document_sync(file_bytes: bytes) -> str:
     """Save the fetched document in the queue's store.
 
@@ -39,13 +53,7 @@ def save_document_sync(file_bytes: bytes) -> str:
     Returns:
         ID in the store where the content was saved.
     """
-
-    async def _save():
-        async with config.queue.store.driver() as store:
-            async with store.tx() as tx:
-                return await CaseStore.save_blob(tx, file_bytes)
-
-    return asyncio.run(_save())
+    return asyncio.run(save_document(file_bytes))
 
 
 def save_retry_state_sync(

--- a/app/server/handlers/extraction.py
+++ b/app/server/handlers/extraction.py
@@ -18,7 +18,7 @@ from ..tasks import (
     inline_document_bytes,
 )
 from ..tasks.extract_callback import ExtractionCallbackTaskResult
-from .redaction import validate_callback_url
+from .redaction import validate_callback_url, validate_document_url
 
 
 def _task_key(token: str) -> str:
@@ -38,6 +38,8 @@ async def extract_documents(
     for doc in body.documents:
         callback_url = str(doc.callbackUrl) if doc.callbackUrl else None
         validate_callback_url(callback_url)
+        if doc.document.root.attachmentType == "LINK":
+            validate_document_url(str(doc.document.root.url))
 
         token = str(uuid7())
         # Persist inline (BASE64) payloads to the blob store up front so the

--- a/app/server/handlers/extraction.py
+++ b/app/server/handlers/extraction.py
@@ -1,6 +1,7 @@
 from fastapi import HTTPException, Request
 from uuid_utils import uuid7
 
+from ..case_helper import save_document
 from ..config import config
 from ..generated.models import (
     ExtractionAccepted,
@@ -11,7 +12,11 @@ from ..generated.models import (
     ExtractionResultSuccess,
     ExtractionStatus,
 )
-from ..tasks import create_document_extraction_task, get_result
+from ..tasks import (
+    create_document_extraction_task,
+    get_result,
+    inline_document_bytes,
+)
 from ..tasks.extract_callback import ExtractionCallbackTaskResult
 from .redaction import validate_callback_url
 
@@ -35,7 +40,16 @@ async def extract_documents(
         validate_callback_url(callback_url)
 
         token = str(uuid7())
-        task_chain = create_document_extraction_task(token, doc)
+        # Persist inline (BASE64) payloads to the blob store up front so the
+        # content skips the broker entirely (see redaction handler for details).
+        prefetched_storage_id: str | None = None
+        inline_bytes = inline_document_bytes(doc.document)
+        if inline_bytes is not None:
+            prefetched_storage_id = await save_document(inline_bytes)
+            del inline_bytes
+        task_chain = create_document_extraction_task(
+            token, doc, prefetched_storage_id=prefetched_storage_id
+        )
         task = task_chain.apply_async()
 
         await request.state.store.set(_task_key(token), task.id)

--- a/app/server/handlers/redaction.py
+++ b/app/server/handlers/redaction.py
@@ -6,7 +6,7 @@ from fastapi import HTTPException, Request
 from nameparser import HumanName
 
 from ..case import CaseStore
-from ..case_helper import get_retry_state, summarize_state
+from ..case_helper import get_retry_state, save_document, summarize_state
 from ..config import config
 from ..generated.models import (
     HumanName as HumanNameModel,
@@ -27,7 +27,11 @@ from ..generated.models import (
 from ..generated.models import (
     Subject as SubjectModel,
 )
-from ..tasks import create_document_redaction_task, get_result
+from ..tasks import (
+    create_document_redaction_task,
+    get_result,
+    inline_document_bytes,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -122,14 +126,29 @@ async def redact_documents(*, request: Request, body: RedactionRequest) -> None:
     # progress, we can't use that context.
     # TODO(jnu): decide if we should just reject the request, or enqueue it.
 
+    # Persist inline (BASE64/TEXT) payloads to the blob store up front so the
+    # (potentially large) document content never has to be serialized into a
+    # Celery message and round-tripped through the broker. This keeps a single
+    # copy of the bytes in the store rather than several copies resident across
+    # the API, broker, and worker simultaneously. LINK documents are left alone
+    # so the worker streams them directly.
+    target = body.objects[0]
+    prefetched_storage_id: str | None = None
+    inline_bytes = inline_document_bytes(target.document)
+    if inline_bytes is not None:
+        prefetched_storage_id = await save_document(inline_bytes)
+        # Drop our local reference promptly so the decoded bytes can be freed.
+        del inline_bytes
+
     # Create a task chain to process the documents. The chain will
     # iteratively create new chains for each document in the request.
     task_chain = create_document_redaction_task(
         body.jurisdictionId,
         body.caseId,
         subj_ids_list,
-        body.objects[0],
+        target,
         renderer=body.outputFormat or OutputFormat.PDF,
+        prefetched_storage_id=prefetched_storage_id,
     )
 
     if not task_chain:

--- a/app/server/handlers/redaction.py
+++ b/app/server/handlers/redaction.py
@@ -31,6 +31,7 @@ from ..tasks import (
     create_document_redaction_task,
     get_result,
     inline_document_bytes,
+    public_link_schemes,
 )
 
 logger = logging.getLogger(__name__)
@@ -39,6 +40,10 @@ logger = logging.getLogger(__name__)
 # Only allow HTTP callbacks in debug mode
 _callback_schemes = {"http", "https"} if config.debug else {"https"}
 _disallowed_callback_hosts = {"localhost", "127.0.0.1"} if not config.debug else set()
+# Document links are validated against the schemes of the registered fetch
+# resolvers (excluding private ones), not the callback scheme set. localhost
+# (etc.) is still rejected outside debug to guard against SSRF.
+_disallowed_document_hosts = {"localhost", "127.0.0.1"} if not config.debug else set()
 
 
 def validate_callback_url(url: str | None) -> None:
@@ -68,10 +73,12 @@ def validate_callback_url(url: str | None) -> None:
 def validate_document_url(url: str | None) -> None:
     """Validate an inbound document LINK url.
 
-    Only external schemes (http/https, https-only outside debug) are accepted.
-    This is what prevents a client from submitting an internal ``bcstore://``
-    link (which would let them read arbitrary staged blobs by id): such links
-    are minted only internally, never accepted from a request.
+    The url scheme must match one of the publicly registered fetch resolvers
+    (see :func:`app.server.tasks.public_link_schemes`). Private resolver schemes
+    are deliberately excluded: this is what prevents a client from submitting an
+    internal ``bcstore://`` link (which would let them read arbitrary staged
+    blobs by id), since such links are minted only internally and never accepted
+    from a request.
 
     Args:
         url (str): The url to validate.
@@ -84,12 +91,15 @@ def validate_document_url(url: str | None) -> None:
     parsed = urlparse(url)
     if not parsed.scheme:
         raise HTTPException(status_code=400, detail="Invalid document URL")
-    if parsed.scheme not in _callback_schemes:
+    allowed_schemes = public_link_schemes()
+    if parsed.scheme.lower() not in allowed_schemes:
         raise HTTPException(
             status_code=400,
-            detail=f"Invalid document URL scheme (must use {_callback_schemes})",
+            detail=(
+                f"Invalid document URL scheme (must use {sorted(allowed_schemes)})"
+            ),
         )
-    if parsed.hostname in _disallowed_callback_hosts:
+    if parsed.hostname in _disallowed_document_hosts:
         raise HTTPException(status_code=400, detail="Invalid document URL host")
 
 

--- a/app/server/handlers/redaction.py
+++ b/app/server/handlers/redaction.py
@@ -65,6 +65,34 @@ def validate_callback_url(url: str | None) -> None:
         raise HTTPException(status_code=400, detail="Invalid callback URL host")
 
 
+def validate_document_url(url: str | None) -> None:
+    """Validate an inbound document LINK url.
+
+    Only external schemes (http/https, https-only outside debug) are accepted.
+    This is what prevents a client from submitting an internal ``bcstore://``
+    link (which would let them read arbitrary staged blobs by id): such links
+    are minted only internally, never accepted from a request.
+
+    Args:
+        url (str): The url to validate.
+
+    Raises:
+        HTTPException: If the url is invalid.
+    """
+    if not url:
+        return
+    parsed = urlparse(url)
+    if not parsed.scheme:
+        raise HTTPException(status_code=400, detail="Invalid document URL")
+    if parsed.scheme not in _callback_schemes:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid document URL scheme (must use {_callback_schemes})",
+        )
+    if parsed.hostname in _disallowed_callback_hosts:
+        raise HTTPException(status_code=400, detail="Invalid document URL host")
+
+
 def validate_redaction_request(body: RedactionRequest) -> None:
     """Validate a redaction request.
 
@@ -83,6 +111,8 @@ def validate_redaction_request(body: RedactionRequest) -> None:
         # TODO - the SAS url validation should be more involved than just "valid URL."
         # We can try to use the Azure SDK to validate the URL.
         validate_callback_url(target_blob_url)
+        if obj.document.root.attachmentType == "LINK":
+            validate_document_url(str(obj.document.root.url))
 
 
 async def redact_documents(*, request: Request, body: RedactionRequest) -> None:

--- a/app/server/tasks/__init__.py
+++ b/app/server/tasks/__init__.py
@@ -12,6 +12,7 @@ from .fetch import (
     UnidentifiedFetchTask,
     fetch,
     fetch_unidentified,
+    inline_document_bytes,
 )
 from .finalize import FinalizeTask, FinalizeTaskResult, finalize
 from .format import FormatTask, FormatTaskResult, format
@@ -25,6 +26,7 @@ __all__ = [
     "callback",
     "fetch",
     "fetch_unidentified",
+    "inline_document_bytes",
     "FetchTask",
     "UnidentifiedFetchTask",
     "FetchTaskResult",

--- a/app/server/tasks/__init__.py
+++ b/app/server/tasks/__init__.py
@@ -13,6 +13,7 @@ from .fetch import (
     fetch,
     fetch_unidentified,
     inline_document_bytes,
+    public_link_schemes,
 )
 from .finalize import FinalizeTask, FinalizeTaskResult, finalize
 from .format import FormatTask, FormatTaskResult, format
@@ -27,6 +28,7 @@ __all__ = [
     "fetch",
     "fetch_unidentified",
     "inline_document_bytes",
+    "public_link_schemes",
     "FetchTask",
     "UnidentifiedFetchTask",
     "FetchTaskResult",

--- a/app/server/tasks/controller.py
+++ b/app/server/tasks/controller.py
@@ -20,6 +20,7 @@ def create_document_redaction_task(
     subject_ids: list[str],
     object: RedactionTarget,
     renderer: OutputFormat = OutputFormat.PDF,
+    prefetched_storage_id: str | None = None,
 ) -> chain | None:
     """Create database objects representing a document redaction task.
 
@@ -29,14 +30,23 @@ def create_document_redaction_task(
         subject_ids (list[str]): The IDs of the subjects to redact.
         object (RedactionTarget): The document to redact.
         renderer (OutputFormat, optional): The output format for the redacted document.
+        prefetched_storage_id (str, optional): Blob-store id of an inline payload
+            that was persisted before dispatch. When provided, the document
+            content is not carried inline through the broker.
 
     Returns:
         chain: The Celery chain representing the redaction pipeline.
     """
+    document_id = object.document.root.documentId
+    if prefetched_storage_id is not None:
+        fetch_task = FetchTask(
+            document_id=document_id,
+            file_storage_id=prefetched_storage_id,
+        )
+    else:
+        fetch_task = FetchTask(document=object.document)
     return chain(
-        FetchTask(
-            document=object.document,
-        ).s(),
+        fetch_task.s(),
         RedactionTask(
             document_id=object.document.root.documentId,
             jurisdiction_id=jurisdiction_id,
@@ -61,13 +71,29 @@ def create_document_redaction_task(
 def create_document_extraction_task(
     token: str,
     object: ExtractionTarget,
+    prefetched_storage_id: str | None = None,
 ) -> chain:
-    """Create celery chain for extraction on one document."""
-    return chain(
-        UnidentifiedFetchTask(
+    """Create celery chain for extraction on one document.
+
+    Args:
+        token (str): The document token / id.
+        object (ExtractionTarget): The document to extract.
+        prefetched_storage_id (str, optional): Blob-store id of an inline payload
+            that was persisted before dispatch. When provided, the document
+            content is not carried inline through the broker.
+    """
+    if prefetched_storage_id is not None:
+        fetch_task = UnidentifiedFetchTask(
+            document_id=token,
+            file_storage_id=prefetched_storage_id,
+        )
+    else:
+        fetch_task = UnidentifiedFetchTask(
             document=object.document,
             document_id=token,
-        ).s(),
+        )
+    return chain(
+        fetch_task.s(),
         ExtractionTask(
             document_id=token,
         ).s(),

--- a/app/server/tasks/controller.py
+++ b/app/server/tasks/controller.py
@@ -6,7 +6,12 @@ from ..generated.models import ExtractionTarget, OutputFormat, RedactionTarget
 from .callback import CallbackTask
 from .extract import ExtractionTask
 from .extract_callback import ExtractionCallbackTask
-from .fetch import FetchTask, UnidentifiedFetchTask
+from .fetch import (
+    FetchTask,
+    UnidentifiedFetchTask,
+    make_bcstore_document,
+    make_unidentified_bcstore_document,
+)
 from .finalize import FinalizeTask
 from .format import FormatTask
 from .redact import RedactionTask
@@ -39,9 +44,11 @@ def create_document_redaction_task(
     """
     document_id = object.document.root.documentId
     if prefetched_storage_id is not None:
+        # Inline content was pre-staged in the blob store; reference it as an
+        # internal bcstore link instead of carrying the payload through the
+        # broker.
         fetch_task = FetchTask(
-            document_id=document_id,
-            file_storage_id=prefetched_storage_id,
+            document=make_bcstore_document(document_id, prefetched_storage_id),
         )
     else:
         fetch_task = FetchTask(document=object.document)
@@ -84,8 +91,8 @@ def create_document_extraction_task(
     """
     if prefetched_storage_id is not None:
         fetch_task = UnidentifiedFetchTask(
+            document=make_unidentified_bcstore_document(prefetched_storage_id),
             document_id=token,
-            file_storage_id=prefetched_storage_id,
         )
     else:
         fetch_task = UnidentifiedFetchTask(

--- a/app/server/tasks/fetch.py
+++ b/app/server/tasks/fetch.py
@@ -1,14 +1,15 @@
 import base64
-from typing import cast
+from typing import Callable, cast
+from urllib.parse import urlparse
 
 import requests
 from celery.canvas import Signature
 from celery.utils.log import get_task_logger
-from pydantic import BaseModel
+from pydantic import AnyUrl, BaseModel
 
 from app.func import allf
 
-from ..case_helper import save_document_sync, save_retry_state_sync
+from ..case_helper import get_document_sync, save_document_sync, save_retry_state_sync
 from ..config import config
 from ..generated.models import (
     DocumentContent,
@@ -31,24 +32,130 @@ from .serializer import register_type
 logger = get_task_logger(__name__)
 
 
+# --------------------------------------------------------------------------- #
+# Document links & fetch-source resolvers
+# --------------------------------------------------------------------------- #
+#
+# Every document is fetched by resolving its LINK url to bytes. The url scheme
+# selects a resolver, which lets external sources (https today; s3/azure-blob
+# later) plug in uniformly. Inline payloads (BASE64/TEXT) submitted to the API
+# are decoded once, persisted to our blob store, and represented as an internal
+# ``bcstore://<storage-id>`` link so the rest of the pipeline only ever deals
+# with links -- the heavy bytes never transit the Celery broker.
+#
+# SECURITY: ``bcstore`` is an *internal* scheme. It must never be accepted from
+# an inbound request (a client could otherwise read arbitrary blobs by id); the
+# API handlers reject any non-http(s) document url before dispatch. Only this
+# module mints ``bcstore`` links.
+
+BCSTORE_SCHEME = "bcstore"
+
+# Resolvers turn a link url (as a string) into raw document bytes.
+LinkResolver = Callable[[str], bytes]
+_LINK_RESOLVERS: dict[str, LinkResolver] = {}
+
+
+def register_link_resolver(scheme: str, resolver: LinkResolver) -> None:
+    """Register a resolver that fetches bytes for links of the given scheme."""
+    _LINK_RESOLVERS[scheme.lower()] = resolver
+
+
+def resolve_link(url: str) -> bytes:
+    """Resolve a document link url to raw bytes via the registered resolvers."""
+    scheme = urlparse(url).scheme.lower()
+    resolver = _LINK_RESOLVERS.get(scheme)
+    if resolver is None:
+        raise ValueError(f"Unsupported document link scheme: {scheme!r}")
+    return resolver(url)
+
+
+def _resolve_http(url: str) -> bytes:
+    response = requests.get(
+        url,
+        timeout=config.queue.task.link_download_timeout_seconds,
+    )
+    response.raise_for_status()
+    return response.content
+
+
+def _resolve_bcstore(url: str) -> bytes:
+    storage_id = bcstore_storage_id_from_url(url)
+    if not storage_id:
+        raise ValueError(f"Malformed {BCSTORE_SCHEME} url: {url!r}")
+    content = get_document_sync(storage_id)
+    if not content:
+        raise ValueError(f"No content in store for {url!r}")
+    return content
+
+
+register_link_resolver("http", _resolve_http)
+register_link_resolver("https", _resolve_http)
+register_link_resolver(BCSTORE_SCHEME, _resolve_bcstore)
+
+
+def bcstore_url(storage_id: str) -> str:
+    """Build an internal ``bcstore://<storage-id>`` link url."""
+    return f"{BCSTORE_SCHEME}://{storage_id}"
+
+
+def bcstore_storage_id_from_url(url: str) -> str | None:
+    """Extract the storage id from a ``bcstore://`` url, or ``None``."""
+    parsed = urlparse(url)
+    if parsed.scheme.lower() != BCSTORE_SCHEME:
+        return None
+    return parsed.netloc or None
+
+
+def bcstore_storage_id(
+    document: InputDocument | UnidentifiedInputDocument,
+) -> str | None:
+    """Return the storage id if ``document`` is an internal ``bcstore`` link.
+
+    Used to short-circuit the fetch step: content behind a ``bcstore`` link is
+    already staged in our store, so we can pass its id downstream without ever
+    loading the bytes into the worker.
+    """
+    root = document.root
+    if root.attachmentType != "LINK":
+        return None
+    return bcstore_storage_id_from_url(str(root.url))
+
+
+def make_bcstore_document(document_id: str, storage_id: str) -> InputDocument:
+    """Build an identified document that points at staged blob-store content."""
+    return InputDocument(
+        root=DocumentLink(
+            attachmentType="LINK",
+            documentId=document_id,
+            url=AnyUrl(bcstore_url(storage_id)),
+        )
+    )
+
+
+def make_unidentified_bcstore_document(storage_id: str) -> UnidentifiedInputDocument:
+    """Build an anonymous document that points at staged blob-store content."""
+    return UnidentifiedInputDocument(
+        root=UnidentifiedDocumentLink(
+            attachmentType="LINK",
+            url=AnyUrl(bcstore_url(storage_id)),
+        )
+    )
+
+
 class FetchTask(BaseModel):
-    # When an inline (BASE64/TEXT) document is persisted to the blob store
-    # before dispatch, the heavy payload travels via ``file_storage_id`` instead
-    # of being carried inline through the broker. In that case ``document`` is
-    # omitted and ``document_id`` identifies the document. For LINK documents the
-    # ``document`` is carried through so the worker downloads it directly.
-    document: InputDocument | None = None
-    document_id: str | None = None
-    file_storage_id: str | None = None
+    # Documents are always represented as links by the time they reach the
+    # fetch task. Inline payloads submitted to the API are pre-staged in the
+    # blob store and carried as an internal ``bcstore://`` link, so this single
+    # field uniformly covers external (https) and internal (bcstore) sources.
+    document: InputDocument
 
     def s(self) -> Signature:
         return fetch.s(self)
 
 
 class UnidentifiedFetchTask(BaseModel):
-    document: UnidentifiedInputDocument | None = None
+    document: UnidentifiedInputDocument
     document_id: str
-    file_storage_id: str | None = None
 
     def s(self) -> Signature:
         return fetch_unidentified.s(self)
@@ -87,16 +194,6 @@ def fetch(self, params: FetchTask) -> FetchTaskResult:
     Returns:
         FetchTaskResult: The task result.
     """
-    # Inline payloads (BASE64/TEXT) are persisted to the blob store before
-    # dispatch so they don't travel through the broker. When that has happened
-    # there's nothing left to fetch -- just pass the storage id downstream.
-    if params.file_storage_id is not None:
-        return FetchTaskResult(
-            document_id=params.document_id or "",
-            file_storage_id=params.file_storage_id,
-        )
-    if params.document is None:
-        raise ValueError("FetchTask requires either a document or a file_storage_id")
     return _fetch_and_save(self, params.document.root.documentId, params.document)
 
 
@@ -115,15 +212,6 @@ def fetch(self, params: FetchTask) -> FetchTaskResult:
 )
 def fetch_unidentified(self, params: UnidentifiedFetchTask) -> FetchTaskResult:
     """Fetch the content of an unidentified input document."""
-    if params.file_storage_id is not None:
-        return FetchTaskResult(
-            document_id=params.document_id,
-            file_storage_id=params.file_storage_id,
-        )
-    if params.document is None:
-        raise ValueError(
-            "UnidentifiedFetchTask requires either a document or a file_storage_id"
-        )
     return _fetch_and_save(self, params.document_id, params.document)
 
 
@@ -137,6 +225,13 @@ def _fetch_and_save(
     Shared implementation for the identified and unidentified fetch tasks.
     """
     try:
+        # Internal (bcstore) links already point at content staged in our
+        # store. Pass the id straight through without loading the bytes into
+        # the worker -- this is what keeps large pre-staged payloads off the
+        # worker's heap during fetch.
+        staged_id = bcstore_storage_id(document)
+        if staged_id is not None:
+            return FetchTaskResult(document_id=document_id, file_storage_id=staged_id)
         content = fetch_document_content(document)
         return FetchTaskResult(
             document_id=document_id,
@@ -185,12 +280,7 @@ def fetch_document_content(
                 url = cast(DocumentLink, document.root).url
             else:
                 url = cast(UnidentifiedDocumentLink, document.root).url
-            response = requests.get(
-                str(url),
-                timeout=config.queue.task.link_download_timeout_seconds,
-            )
-            response.raise_for_status()
-            return response.content
+            return resolve_link(str(url))
         case "TEXT":
             if not isinstance(document, InputDocument):
                 raise ValueError("TEXT attachment is not supported for anonymous docs.")

--- a/app/server/tasks/fetch.py
+++ b/app/server/tasks/fetch.py
@@ -32,15 +32,23 @@ logger = get_task_logger(__name__)
 
 
 class FetchTask(BaseModel):
-    document: InputDocument
+    # When an inline (BASE64/TEXT) document is persisted to the blob store
+    # before dispatch, the heavy payload travels via ``file_storage_id`` instead
+    # of being carried inline through the broker. In that case ``document`` is
+    # omitted and ``document_id`` identifies the document. For LINK documents the
+    # ``document`` is carried through so the worker downloads it directly.
+    document: InputDocument | None = None
+    document_id: str | None = None
+    file_storage_id: str | None = None
 
     def s(self) -> Signature:
         return fetch.s(self)
 
 
 class UnidentifiedFetchTask(BaseModel):
-    document: UnidentifiedInputDocument
+    document: UnidentifiedInputDocument | None = None
     document_id: str
+    file_storage_id: str | None = None
 
     def s(self) -> Signature:
         return fetch_unidentified.s(self)
@@ -79,6 +87,16 @@ def fetch(self, params: FetchTask) -> FetchTaskResult:
     Returns:
         FetchTaskResult: The task result.
     """
+    # Inline payloads (BASE64/TEXT) are persisted to the blob store before
+    # dispatch so they don't travel through the broker. When that has happened
+    # there's nothing left to fetch -- just pass the storage id downstream.
+    if params.file_storage_id is not None:
+        return FetchTaskResult(
+            document_id=params.document_id or "",
+            file_storage_id=params.file_storage_id,
+        )
+    if params.document is None:
+        raise ValueError("FetchTask requires either a document or a file_storage_id")
     return _fetch_and_save(self, params.document.root.documentId, params.document)
 
 
@@ -97,6 +115,15 @@ def fetch(self, params: FetchTask) -> FetchTaskResult:
 )
 def fetch_unidentified(self, params: UnidentifiedFetchTask) -> FetchTaskResult:
     """Fetch the content of an unidentified input document."""
+    if params.file_storage_id is not None:
+        return FetchTaskResult(
+            document_id=params.document_id,
+            file_storage_id=params.file_storage_id,
+        )
+    if params.document is None:
+        raise ValueError(
+            "UnidentifiedFetchTask requires either a document or a file_storage_id"
+        )
     return _fetch_and_save(self, params.document_id, params.document)
 
 
@@ -125,6 +152,27 @@ def _fetch_and_save(
             document_id=document_id,
             errors=[ProcessingError.from_exception("fetch", e)],
         )
+
+
+def inline_document_bytes(
+    document: InputDocument | UnidentifiedInputDocument,
+) -> bytes | None:
+    """Decode an inline (BASE64/TEXT) document payload to raw bytes.
+
+    Returns ``None`` for non-inline attachment types (e.g. LINK), whose bytes
+    are not present in the request and should be fetched by the worker instead.
+
+    This lets the API persist inline payloads to the blob store up front so the
+    (potentially large) content never has to be serialized into a Celery
+    message and round-tripped through the broker.
+    """
+    match document.root.attachmentType:
+        case "BASE64":
+            return base64.b64decode(document.root.content)
+        case "TEXT":
+            return document.root.content.encode("utf-8")
+        case _:
+            return None
 
 
 def fetch_document_content(

--- a/app/server/tasks/fetch.py
+++ b/app/server/tasks/fetch.py
@@ -1,4 +1,5 @@
 import base64
+from dataclasses import dataclass
 from typing import Callable, cast
 from urllib.parse import urlparse
 
@@ -52,21 +53,55 @@ BCSTORE_SCHEME = "bcstore"
 
 # Resolvers turn a link url (as a string) into raw document bytes.
 LinkResolver = Callable[[str], bytes]
-_LINK_RESOLVERS: dict[str, LinkResolver] = {}
 
 
-def register_link_resolver(scheme: str, resolver: LinkResolver) -> None:
-    """Register a resolver that fetches bytes for links of the given scheme."""
-    _LINK_RESOLVERS[scheme.lower()] = resolver
+@dataclass(frozen=True)
+class _ResolverEntry:
+    resolver: LinkResolver
+    # Private schemes are internal-only: they can be resolved by the worker but
+    # must never be accepted on an inbound document link (see ``bcstore`` note
+    # above). They are excluded from :func:`public_link_schemes`.
+    private: bool
+
+
+_LINK_RESOLVERS: dict[str, _ResolverEntry] = {}
+
+
+def register_link_resolver(
+    scheme: str,
+    resolver: LinkResolver,
+    *,
+    private: bool = False,
+) -> None:
+    """Register a resolver that fetches bytes for links of the given scheme.
+
+    Args:
+        scheme: The url scheme this resolver handles (case-insensitive).
+        resolver: Callable turning a link url into raw document bytes.
+        private: When True, the scheme is internal-only and must never be
+            accepted from an inbound request (e.g. ``bcstore``). Private schemes
+            are excluded from :func:`public_link_schemes`.
+    """
+    _LINK_RESOLVERS[scheme.lower()] = _ResolverEntry(resolver=resolver, private=private)
+
+
+def public_link_schemes() -> set[str]:
+    """Return schemes that may be submitted on an inbound document link.
+
+    This is the source of truth for input document url validation: every
+    publicly registered resolver is accepted, while private schemes (e.g. the
+    internal ``bcstore`` scheme) are withheld so clients cannot submit them.
+    """
+    return {scheme for scheme, entry in _LINK_RESOLVERS.items() if not entry.private}
 
 
 def resolve_link(url: str) -> bytes:
     """Resolve a document link url to raw bytes via the registered resolvers."""
     scheme = urlparse(url).scheme.lower()
-    resolver = _LINK_RESOLVERS.get(scheme)
-    if resolver is None:
+    entry = _LINK_RESOLVERS.get(scheme)
+    if entry is None:
         raise ValueError(f"Unsupported document link scheme: {scheme!r}")
-    return resolver(url)
+    return entry.resolver(url)
 
 
 def _resolve_http(url: str) -> bytes:
@@ -88,9 +123,15 @@ def _resolve_bcstore(url: str) -> bytes:
     return content
 
 
-register_link_resolver("http", _resolve_http)
 register_link_resolver("https", _resolve_http)
-register_link_resolver(BCSTORE_SCHEME, _resolve_bcstore)
+# Plain http is only allowed in debug; production accepts https-only document
+# links. Registering it conditionally keeps the resolver registry the single
+# source of truth for input scheme validation.
+if config.debug:
+    register_link_resolver("http", _resolve_http)
+# bcstore is internal-only: the worker resolves it, but clients must not be
+# able to submit it (it would let them read arbitrary staged blobs by id).
+register_link_resolver(BCSTORE_SCHEME, _resolve_bcstore, private=True)
 
 
 def bcstore_url(storage_id: str) -> str:

--- a/app/server/tasks/finalize.py
+++ b/app/server/tasks/finalize.py
@@ -9,11 +9,12 @@ from pydantic import BaseModel
 from app.func import allf
 
 from ..case import CaseStore
-from ..case_helper import save_retry_state_sync, summarize_state
+from ..case_helper import save_document_sync, save_retry_state_sync, summarize_state
 from ..config import config
 from ..db import DocumentStatus
 from ..generated.models import OutputFormat, RedactionTarget
 from .callback import CallbackTaskResult, get_result_sync
+from .fetch import inline_document_bytes
 from .metrics import (
     celery_counters,
     record_task_failure,
@@ -128,12 +129,22 @@ def finalize(
     if next_object:
         from .controller import create_document_redaction_task
 
+        # Keep inline (BASE64/TEXT) payloads out of the broker on the iterative
+        # multi-object path too: persist the content to the blob store and pass
+        # only its id into the next chain (mirrors the API handler).
+        prefetched_storage_id: str | None = None
+        inline_bytes = inline_document_bytes(next_object.document)
+        if inline_bytes is not None:
+            prefetched_storage_id = save_document_sync(inline_bytes)
+            del inline_bytes
+
         new_chain = create_document_redaction_task(
             params.jurisdiction_id,
             params.case_id,
             params.subject_ids,
             next_object,
             renderer=params.renderer,
+            prefetched_storage_id=prefetched_storage_id,
         )
         if not new_chain:
             # Unclear why we would get here, since we've verified that

--- a/tests/unit/test_fetch.py
+++ b/tests/unit/test_fetch.py
@@ -6,7 +6,20 @@ from app.server.generated.models import (
     DocumentText,
     InputDocument,
 )
-from app.server.tasks import FetchTask, FetchTaskResult, fetch
+from app.server.tasks import FetchTask, FetchTaskResult, fetch, public_link_schemes
+
+
+def test_public_link_schemes_excludes_private():
+    """Public input schemes cover the http(s) resolvers but not bcstore.
+
+    Input document urls are validated against this set, so the internal
+    ``bcstore`` scheme (registered as private) must be withheld to prevent
+    clients from submitting internal blob-store links.
+    """
+    schemes = public_link_schemes()
+    assert "http" in schemes
+    assert "https" in schemes
+    assert "bcstore" not in schemes
 
 
 @responses.activate

--- a/tests/unit/test_fetch.py
+++ b/tests/unit/test_fetch.py
@@ -37,6 +37,34 @@ def test_fetch_link():
 
 
 @responses.activate
+def test_fetch_bcstore_link_short_circuits():
+    """A bcstore link passes its storage id through without loading bytes.
+
+    No HTTP resolver is registered for the bcstore scheme, so if the fetch task
+    tried to *download* it (rather than short-circuit), this would error. The
+    storage id should come straight back as the result.
+    """
+    storage_id = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+
+    params = FetchTask(
+        document=InputDocument(
+            root=DocumentLink(
+                documentId="doc1",
+                attachmentType="LINK",
+                url=f"bcstore://{storage_id}",
+            )
+        )
+    )
+
+    result = fetch.s(params).apply()
+
+    assert result.get() == FetchTaskResult(
+        document_id="doc1",
+        file_storage_id=storage_id,
+    )
+
+
+@responses.activate
 def test_fetch_link_error_code():
     responses.add(
         responses.GET,

--- a/tests/unit/test_redact_handler.py
+++ b/tests/unit/test_redact_handler.py
@@ -1,3 +1,5 @@
+import base64
+import hashlib
 from typing import cast
 from unittest.mock import MagicMock, patch
 
@@ -7,7 +9,11 @@ from fastapi.testclient import TestClient
 from glowplug import DbDriver
 from pydantic import AnyUrl
 
-from app.server.generated.models import DocumentLink, InputDocument, OutputFormat
+from app.server.generated.models import (
+    DocumentLink,
+    InputDocument,
+    OutputFormat,
+)
 from app.server.tasks import (
     CallbackTask,
     FetchTask,
@@ -349,3 +355,60 @@ async def test_redact_handler_multi_doc(
             b'"url": "https://test_document.pdf/"}, "targetBlobUrl": null}'
         ),
     ]
+
+
+@patch("app.server.tasks.controller.chain")
+async def test_redact_handler_base64_payload_skips_broker(
+    chain_mock: MagicMock,
+    api: TestClient,
+    exp_db: DbDriver,
+    fake_redis_store: FakeRedis,
+):
+    """Inline BASE64 content is persisted to the blob store before dispatch.
+
+    Rather than carrying the (potentially large) document inline through the
+    Celery broker, the handler decodes it once, writes it to the blob store,
+    and the fetch task carries only the storage id. This is the headroom fix
+    for the BASE64 attachment path.
+    """
+    chain_mock.return_value.apply_async.return_value = AsyncResult("fake_task_id")
+
+    raw = b"%PDF-1.4 fake document bytes"
+    storage_id = hashlib.sha256(raw).hexdigest()
+
+    request = {
+        "jurisdictionId": "jur1",
+        "caseId": "case1",
+        "subjects": [
+            {
+                "role": "accused",
+                "subject": {"subjectId": "sub1", "name": "jack doe"},
+            }
+        ],
+        "objects": [
+            {
+                "document": {
+                    "attachmentType": "BASE64",
+                    "documentId": "doc1",
+                    "content": base64.b64encode(raw).decode("ascii"),
+                },
+                "callbackUrl": "https://echo",
+            }
+        ],
+    }
+
+    response = api.post("/api/v1/redact", json=request)
+    assert response.status_code == 201
+
+    # The fetch task should carry only the storage id, with no inline document.
+    chain_mock.assert_called_once()
+    fetch_sig = chain_mock.mock_calls[0].args[0]
+    assert fetch_sig == fetch.s(
+        FetchTask(document_id="doc1", file_storage_id=storage_id)
+    )
+    fetch_task = fetch_sig.args[0]
+    assert fetch_task.document is None
+    assert fetch_task.file_storage_id == storage_id
+
+    # The decoded bytes (not the base64 string) live in the blob store.
+    assert fake_redis_store.get(storage_id) == raw

--- a/tests/unit/test_redact_handler.py
+++ b/tests/unit/test_redact_handler.py
@@ -368,8 +368,8 @@ async def test_redact_handler_base64_payload_skips_broker(
 
     Rather than carrying the (potentially large) document inline through the
     Celery broker, the handler decodes it once, writes it to the blob store,
-    and the fetch task carries only the storage id. This is the headroom fix
-    for the BASE64 attachment path.
+    and the fetch task references it via an internal ``bcstore://`` link. This
+    is the headroom fix for the BASE64 attachment path.
     """
     chain_mock.return_value.apply_async.return_value = AsyncResult("fake_task_id")
 
@@ -400,15 +400,51 @@ async def test_redact_handler_base64_payload_skips_broker(
     response = api.post("/api/v1/redact", json=request)
     assert response.status_code == 201
 
-    # The fetch task should carry only the storage id, with no inline document.
+    # The fetch task should carry an internal bcstore link, not the payload.
     chain_mock.assert_called_once()
     fetch_sig = chain_mock.mock_calls[0].args[0]
     assert fetch_sig == fetch.s(
-        FetchTask(document_id="doc1", file_storage_id=storage_id)
+        FetchTask(
+            document=InputDocument(
+                root=DocumentLink(
+                    attachmentType="LINK",
+                    documentId="doc1",
+                    url=AnyUrl(f"bcstore://{storage_id}"),
+                )
+            )
+        )
     )
-    fetch_task = fetch_sig.args[0]
-    assert fetch_task.document is None
-    assert fetch_task.file_storage_id == storage_id
 
     # The decoded bytes (not the base64 string) live in the blob store.
     assert fake_redis_store.get(storage_id) == raw
+
+
+async def test_redact_handler_rejects_internal_document_scheme(
+    api: TestClient,
+    exp_db: DbDriver,
+    fake_redis_store: FakeRedis,
+):
+    """A client must not be able to submit an internal ``bcstore://`` link."""
+    request = {
+        "jurisdictionId": "jur1",
+        "caseId": "case1",
+        "subjects": [
+            {
+                "role": "accused",
+                "subject": {"subjectId": "sub1", "name": "jack doe"},
+            }
+        ],
+        "objects": [
+            {
+                "document": {
+                    "attachmentType": "LINK",
+                    "documentId": "doc1",
+                    "url": "bcstore://deadbeef",
+                },
+                "callbackUrl": "https://echo",
+            }
+        ],
+    }
+
+    response = api.post("/api/v1/redact", json=request)
+    assert response.status_code == 400


### PR DESCRIPTION
**Problem**
Users reported OOM-killed containers under circumstances involving multiple large (~10s of MB) documents processed at once using BASE64 attachment type.

**Background**
We tried to solve operationally by scaling up number of container app instances. However, this does not fully address the issue, just defers it. It's also an expensive fix to provision more compute and memory for this purpose. A better fix than adding more replicas would be to increase memory to each container, however container apps has limitations there that make it difficult to do this without restructuring the terraform configuration and deployment, also with significant added cost.

In terms of code and API design, there is inherently always going to be memory pressure _somewhere_ in the stack for large documents at a certain volume. Normally software addresses this problem by trading of time and memory, such as by offloading large documents to a slower storage, either disk or a cloud storage, and paging relevant pieces into memory for processing in smaller chunks. In the case of blind charging, we have a constraint that we keep all data in volatile storage, and never roll it onto disk, for privacy reasons. So, this application will always have memory pressure somewhere.

With that said, we designed the LINK attachmentType in the API schema to avoid this problem -- let the client store data in a secure space of their choosing and give us a pointer to it. We'll store the file in memory for processing, then dispose of it.

We have *not* heard reports of, nor easily design a test case to simulate, OOM-killing with the LINK attachment type. So, though there are of course going to be limitations, we should be able to improve the direct file attachment to approach the level of performance of the LINK type.

The BASE64 attachment type is suboptimal for several reasons. It would be better to implement a strategy that takes advantage of chunked binary file uploads, to avoid the marginal size bloat inherent to the BASE64 encoding, and to let the API process the file naturally in chunks. The thinking originally was that embedding the binary content in a JSON blob with base64 would be easier for the clients to manage (since a JSON blob of metadata is required in the request, to accompany the file contents), and on the server-side, the starlette framework handles large uploads by paging to disk, which we needed to avoid. In the future we may opt to design a BINARY attachment type, but for now we aim to improve the BASE64 type without requesting clients to change their behavior at all.

**Diagnosis**
There turns out to be significant headroom to improve BASE64 attachment performance without any interface changes. The full file content was inadvertently being multiplied and passed around in data blobs (such as in the Celery signature) that quickly caused memory usage to explode. One 70mb document would quickly occupy >5x this space in memory, causing even modest usage involving large files to trigger an OOM condition, restart the container, and perhaps never succeed.

**Fix**
The solution is to play "hot potato" with the file data. Similar to LINK, we can generate a pointer to the file (still in memory, in our redis store) as soon as the API receives the request, and pass the pointer around in the task definition, freeing all the memory previously wasted on shuffling around the large file content unnecessarily.

**Testing**
The new load testing framework confirms that performance approaches that of the LINK attachment type. New and existing integration and existing unit testing confirms proper behavior.