### PR TITLE
Make db max size configurable, increase limit

### DIFF
--- a/terraform/db.tf
+++ b/terraform/db.tf
@@ -30,7 +30,7 @@ resource "azurerm_mssql_database" "main" {
   name           = local.mssql_database_name
   server_id      = azurerm_mssql_server.main.id
   collation      = "SQL_Latin1_General_CP1_CI_AS"
-  max_size_gb    = 5
+  max_size_gb    = var.db_max_size_gb
   sku_name       = "S0"
   zone_redundant = false
   tags           = var.tags

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -37,6 +37,12 @@ variable "db_password" {
   description = "Admin password for the MSSQL database. This can be any strong string and should be rotated periodically."
 }
 
+variable "db_max_size_gb" {
+  type        = number
+  default     = 5
+  description = "Database storage size (GB)"
+}
+
 variable "location" {
   type        = string
   default     = "usgovvirginia"

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -39,7 +39,7 @@ variable "db_password" {
 
 variable "db_max_size_gb" {
   type        = number
-  default     = 5
+  default     = 20
   description = "Database storage size (GB)"
 }
 


### PR DESCRIPTION
Based on empirical evidence, 5gb is not generous enough to accommodate research data under high volume over the lifespan of our experiment. Bumping the default to 20gb and making this setting configurable by deployment. The max value will be 250gb. Billing still based on DTUs, so not directly affected by the max size set in this parameter.

