### PR TITLE
Make document status writes in finalize best effort

### DIFF
--- a/app/server/tasks/finalize.py
+++ b/app/server/tasks/finalize.py
@@ -110,16 +110,12 @@ def finalize(
     celery_counters.record_job(bool(final_errors))
 
     if config.experiments.enabled:
-        with config.experiments.store.driver.sync_session() as session:
-            status = DocumentStatus(
-                jurisdiction_id=format_result.jurisdiction_id,
-                case_id=format_result.case_id,
-                document_id=format_result.document_id,
-                status="ERROR" if final_errors else "COMPLETE",
-                error=format_errors(final_errors),
-            )
-            session.add(status)
-            session.commit()
+        save_document_status_sync(
+            format_result.jurisdiction_id,
+            format_result.case_id,
+            format_result.document_id,
+            final_errors,
+        )
 
     # Queue up the next document for processing now, if there is one.
     next_task: AsyncResult | None = None
@@ -174,6 +170,32 @@ def format_errors(errors: list[ProcessingError]) -> str | None:
     if not errors:
         return None
     return json.dumps([err.model_dump() for err in errors])
+
+
+def save_document_status_sync(
+    jurisdiction_id: str,
+    case_id: str,
+    document_id: str,
+    errors: list[ProcessingError],
+) -> None:
+    try:
+        with config.experiments.store.driver.sync_session() as session:
+            status = DocumentStatus(
+                jurisdiction_id=jurisdiction_id,
+                case_id=case_id,
+                document_id=document_id,
+                status="ERROR" if errors else "COMPLETE",
+                error=format_errors(errors),
+            )
+            session.add(status)
+            session.commit()
+    except Exception:
+        logger.exception(
+            "Failed to save document status for %s:%s:%s",
+            jurisdiction_id,
+            case_id,
+            document_id,
+        )
 
 
 def get_next_object_sync(jurisdiction_id: str, case_id: str) -> RedactionTarget | None:

--- a/tests/unit/test_finalize.py
+++ b/tests/unit/test_finalize.py
@@ -396,6 +396,74 @@ def test_finalize_preserves_upstream_errors_without_verifying(
         assert ds[0].status == "ERROR"
 
 
+@patch("app.server.tasks.finalize.config.experiments.store.driver.sync_session")
+@patch("app.server.tasks.controller.chain")
+def test_finalize_status_write_failure_still_processes_next_object(
+    chain_mock, sync_session_mock, config, exp_db, fake_redis_store
+):
+    config.experiments.enabled = True
+    _seed_result_doc(fake_redis_store)
+    sync_session_mock.side_effect = RuntimeError("db unavailable")
+    chain_mock.return_value.apply_async.return_value = AsyncResult("new_task_id")
+
+    fake_redis_store.rpush(
+        "jur1:case1:objects",
+        '{"callbackUrl": "https://echo/2", "document": '
+        '{"attachmentType": "LINK", "documentId": "doc2", '
+        '"url": "https://test_document.pdf/"}, "targetBlobUrl": null}',
+    )
+    fake_redis_store.rpush(
+        "jur1:case1:objects",
+        '{"callbackUrl": "https://echo/1", "document": '
+        '{"attachmentType": "LINK", "documentId": "doc1", '
+        '"url": "https://test_document.pdf/"}, "targetBlobUrl": null}',
+    )
+    fake_redis_store.hset("jur1:case1:task", "doc1", "fake_task_id")
+
+    cb = CallbackTaskResult(
+        status_code=200,
+        response="ok",
+        formatted=FormatTaskResult(
+            document=OutputDocument(
+                root=DocumentLink(
+                    documentId="doc1",
+                    attachmentType="LINK",
+                    url="http://blob.test.local/abc123",
+                )
+            ),
+            jurisdiction_id="jur1",
+            case_id="case1",
+            document_id="doc1",
+            errors=[],
+        ),
+    )
+    ft = FinalizeTask(
+        jurisdiction_id="jur1",
+        case_id="case1",
+        subject_ids=[],
+        renderer="PDF",
+    )
+
+    result = finalize.s(cb, ft).apply()
+
+    assert result.get() == FinalizeTaskResult.model_validate(
+        {
+            "jurisdiction_id": "jur1",
+            "case_id": "case1",
+            "document_id": "doc1",
+            "document": {
+                "documentId": "doc1",
+                "attachmentType": "LINK",
+                "url": "http://blob.test.local/abc123",
+            },
+            "errors": [],
+            "next_task_id": "new_task_id",
+        }
+    )
+    assert fake_redis_store.llen("jur1:case1:objects") == 0
+    assert fake_redis_store.hget("jur1:case1:task", "doc2") == b"new_task_id"
+
+
 @patch("app.server.tasks.controller.chain")
 def test_finalize_no_experiments_more_objects(chain_mock, config, fake_redis_store):
     config.experiments.enabled = False


### PR DESCRIPTION
When experiments are enabled, we can hit an issue that writing research data to the research database can fail in the `finalize` task, breaking this task. This is not an issue for single-document requests, but prevents subsequent documents in multi-document requests from being processed.

This PR makes the write to the database best-effort, so that only non-critical data will be lost and subsequent redactions can continue normally.