### PR TITLE
Migrate KeyVault access policies to RBAC

### DIFF
--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -45,12 +45,20 @@ resource "azurerm_key_vault_secret" "app_config" {
   name         = "app-config"
   key_vault_id = azurerm_key_vault.main.id
   value        = local.app_config_toml
+  depends_on = [
+    azurerm_role_assignment.current_key_vault_admin,
+    azurerm_role_assignment.admin_key_vault_secrets,
+  ]
 }
 
 resource "azurerm_key_vault_secret" "registry_password" {
   name         = "registry-password"
   key_vault_id = azurerm_key_vault.main.id
   value        = var.registry_password
+  depends_on = [
+    azurerm_role_assignment.current_key_vault_admin,
+    azurerm_role_assignment.admin_key_vault_secrets,
+  ]
 }
 
 resource "azurerm_container_app" "main" {

--- a/terraform/backend/init.sh
+++ b/terraform/backend/init.sh
@@ -108,6 +108,25 @@ az group show --name $tfstate_resource_group &> /dev/null || \
   az group create --name $tfstate_resource_group --location $location --tags "$TAGS"
 
 UPN=$(az account show --query user.name -o tsv)
+
+ensure_role_assignment () {
+  local assignee="$1"
+  local role="$2"
+  local scope="$3"
+
+  if [ "$(az role assignment list --assignee "$assignee" --role "$role" --scope "$scope" --query 'length(@)' -o tsv)" = "0" ]; then
+    az role assignment create --assignee "$assignee" --role "$role" --scope "$scope" > /dev/null
+    ROLE_ASSIGNMENT_CREATED=true
+  fi
+}
+
+wait_for_rbac_if_needed () {
+  if [ "$ROLE_ASSIGNMENT_CREATED" = true ]; then
+    echo "Waiting for Azure RBAC role assignments to propagate ..."
+    sleep 30
+  fi
+}
+
 # Create the key vault if it doesn't exist
 az keyvault show --name $KEYVAULT_NAME --resource-group $tfstate_resource_group &> /dev/null || \
   az keyvault create --name $KEYVAULT_NAME --resource-group $tfstate_resource_group --location $location \
@@ -118,21 +137,23 @@ az keyvault show --name $KEYVAULT_NAME --resource-group $tfstate_resource_group 
   --enabled-for-template-deployment true \
   --enable-purge-protection true \
   --retention-days 90 \
-  --enable-rbac-authorization false \
+  --enable-rbac-authorization true \
   --sku "premium" \
   --tags "$TAGS"
 
-# Ensure purge protection is enabled (for keyvaults created with older version of script)
+# Ensure purge protection and RBAC are enabled (for keyvaults created with older version of script)
 az keyvault update --name $KEYVAULT_NAME --resource-group $tfstate_resource_group \
   --enable-purge-protection true \
   --retention-days 90 \
-  --enable-rbac-authorization false
+  --enable-rbac-authorization true
 
-# Ensure current user has create key access to vault
-az keyvault set-policy --name $KEYVAULT_NAME --resource-group $tfstate_resource_group \
-  --upn $UPN \
-  --key-permissions create get list setrotationpolicy update delete \
-  --secret-permissions get list set delete
+KEYVAULT_ID=$(az keyvault show --name $KEYVAULT_NAME --resource-group $tfstate_resource_group --query id -o tsv)
+
+# Ensure current user has access to manage keys and secrets in the vault.
+ROLE_ASSIGNMENT_CREATED=false
+ensure_role_assignment "$UPN" "Key Vault Crypto Officer" "$KEYVAULT_ID"
+ensure_role_assignment "$UPN" "Key Vault Secrets Officer" "$KEYVAULT_ID"
+wait_for_rbac_if_needed
 
 
 tput setaf 3
@@ -188,11 +209,11 @@ az storage account show --name $STORAGE_ACCOUNT --resource-group $tfstate_resour
 # Ensure the account uses a system-assigned identity
 az storage account update --name $STORAGE_ACCOUNT --resource-group $tfstate_resource_group --identity-type SystemAssigned
 
-# Ensure the access policy is set so that the storage account can access the key vault
+# Ensure the storage account can use the key vault key for encryption.
 STORAGE_ACCOUNT_PRINCIPAL_ID=$(az storage account show --name $STORAGE_ACCOUNT --resource-group $tfstate_resource_group --query 'identity.principalId' -o tsv)
-az keyvault set-policy --name $KEYVAULT_NAME --resource-group $tfstate_resource_group \
-  --object-id $STORAGE_ACCOUNT_PRINCIPAL_ID \
-  --key-permissions get wrapKey unwrapKey
+ROLE_ASSIGNMENT_CREATED=false
+ensure_role_assignment "$STORAGE_ACCOUNT_PRINCIPAL_ID" "Key Vault Crypto Service Encryption User" "$KEYVAULT_ID"
+wait_for_rbac_if_needed
 
 # Ensure that encryption via user-managed key is configured on the account
 KEYVAULT_URI=$(az keyvault show --name $KEYVAULT_NAME --resource-group $tfstate_resource_group --query properties.vaultUri -o tsv)

--- a/terraform/certificate.tf
+++ b/terraform/certificate.tf
@@ -77,6 +77,10 @@ resource "azurerm_key_vault_certificate" "app_gateway" {
   count        = local.has_cert ? 1 : 0
   name         = "app-gateway-cert"
   key_vault_id = azurerm_key_vault.main.id
+  depends_on = [
+    azurerm_role_assignment.current_key_vault_admin,
+    azurerm_role_assignment.gateway_key_vault_secrets,
+  ]
   certificate {
     contents = local.use_self_signed_cert ? pkcs12_from_pem.app_gateway[0].result : local.use_lets_encrypt_cert ? acme_certificate.app_gateway[0].certificate_p12 : local.use_file_cert ? filebase64(var.ssl_p12_file) : null
     password = var.ssl_cert_password

--- a/terraform/key_vault.tf
+++ b/terraform/key_vault.tf
@@ -21,7 +21,7 @@ resource "azurerm_key_vault" "main" {
   enabled_for_disk_encryption     = true
   enabled_for_template_deployment = true
   enabled_for_deployment          = true
-  enable_rbac_authorization       = false
+  enable_rbac_authorization       = true
   soft_delete_retention_days      = 7
   purge_protection_enabled        = true
   # TODO(jnu): ideally public network access is locked down, but it
@@ -30,58 +30,6 @@ resource "azurerm_key_vault" "main" {
   # NOTE(jnu) - premium is required for HSM keys
   sku_name  = "premium"
   tenant_id = azurerm_user_assigned_identity.admin.tenant_id
-
-  access_policy {
-    tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.object_id
-    certificate_permissions = [
-      "Create",
-      "Delete",
-      "DeleteIssuers",
-      "Get",
-      "GetIssuers",
-      "Import",
-      "List",
-      "ListIssuers",
-      "ManageContacts",
-      "ManageIssuers",
-      "Purge",
-      "SetIssuers",
-      "Update",
-    ]
-    secret_permissions = ["Get", "Set", "Delete", "Purge", "Recover", "List"]
-    key_permissions = [
-      "Get",
-      "Update",
-      "Create",
-      "Delete",
-      "List",
-      "Restore",
-      "Recover",
-      "UnwrapKey",
-      "WrapKey",
-      "Purge",
-      "Encrypt",
-      "Decrypt",
-      "Sign",
-      "Verify",
-      "GetRotationPolicy",
-      "SetRotationPolicy"
-    ]
-  }
-
-  access_policy {
-    tenant_id          = azurerm_user_assigned_identity.admin.tenant_id
-    object_id          = azurerm_user_assigned_identity.admin.principal_id
-    key_permissions    = ["Get", "WrapKey", "UnwrapKey"]
-    secret_permissions = ["Get", "List", "Backup", "Restore", "Recover"]
-  }
-
-  access_policy {
-    tenant_id          = azurerm_user_assigned_identity.gateway.tenant_id
-    object_id          = azurerm_user_assigned_identity.gateway.principal_id
-    secret_permissions = ["Get"]
-  }
 }
 
 # NOTE(jnu): When OpenAI is deployed in a separate location from the main resources,
@@ -94,40 +42,49 @@ resource "azurerm_key_vault" "oai" {
   enabled_for_disk_encryption     = true
   enabled_for_template_deployment = true
   enabled_for_deployment          = true
-  enable_rbac_authorization       = false
+  enable_rbac_authorization       = true
   soft_delete_retention_days      = 7
   purge_protection_enabled        = true
   sku_name                        = "premium"
   tenant_id                       = azurerm_user_assigned_identity.admin.tenant_id
+}
 
-  access_policy {
-    tenant_id          = data.azurerm_client_config.current.tenant_id
-    object_id          = data.azurerm_client_config.current.object_id
-    secret_permissions = ["Get", "Set", "Delete", "Purge", "Recover", "List"]
-    key_permissions = [
-      "Get",
-      "Create",
-      "Delete",
-      "List",
-      "Restore",
-      "Recover",
-      "UnwrapKey",
-      "WrapKey",
-      "Purge",
-      "Encrypt",
-      "Decrypt",
-      "Sign",
-      "Verify",
-      "GetRotationPolicy",
-      "SetRotationPolicy"
-    ]
-  }
+resource "azurerm_role_assignment" "current_key_vault_admin" {
+  scope                = azurerm_key_vault.main.id
+  role_definition_name = "Key Vault Administrator"
+  principal_id         = data.azurerm_client_config.current.object_id
+}
 
-  access_policy {
-    tenant_id       = azurerm_user_assigned_identity.admin.tenant_id
-    object_id       = azurerm_user_assigned_identity.admin.principal_id
-    key_permissions = ["Get", "WrapKey", "UnwrapKey"]
-  }
+resource "azurerm_role_assignment" "admin_key_vault_crypto" {
+  scope                = azurerm_key_vault.main.id
+  role_definition_name = "Key Vault Crypto Service Encryption User"
+  principal_id         = azurerm_user_assigned_identity.admin.principal_id
+}
+
+resource "azurerm_role_assignment" "admin_key_vault_secrets" {
+  scope                = azurerm_key_vault.main.id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = azurerm_user_assigned_identity.admin.principal_id
+}
+
+resource "azurerm_role_assignment" "gateway_key_vault_secrets" {
+  scope                = azurerm_key_vault.main.id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = azurerm_user_assigned_identity.gateway.principal_id
+}
+
+resource "azurerm_role_assignment" "current_oai_key_vault_admin" {
+  count                = local.needs_openai_kv ? 1 : 0
+  scope                = azurerm_key_vault.oai[0].id
+  role_definition_name = "Key Vault Administrator"
+  principal_id         = data.azurerm_client_config.current.object_id
+}
+
+resource "azurerm_role_assignment" "admin_oai_key_vault_crypto" {
+  count                = local.needs_openai_kv ? 1 : 0
+  scope                = azurerm_key_vault.oai[0].id
+  role_definition_name = "Key Vault Crypto Service Encryption User"
+  principal_id         = azurerm_user_assigned_identity.admin.principal_id
 }
 
 resource "azurerm_key_vault_key" "encryption" {
@@ -136,6 +93,10 @@ resource "azurerm_key_vault_key" "encryption" {
   key_type     = "RSA-HSM"
   key_size     = 2048
   key_opts     = ["unwrapKey", "wrapKey", "decrypt", "encrypt", "sign", "verify"]
+  depends_on = [
+    azurerm_role_assignment.current_key_vault_admin,
+    azurerm_role_assignment.admin_key_vault_crypto,
+  ]
 
   rotation_policy {
     automatic {
@@ -158,6 +119,10 @@ resource "azurerm_key_vault_key" "oai" {
   key_type     = "RSA-HSM"
   key_size     = 2048
   key_opts     = ["unwrapKey", "wrapKey", "decrypt", "encrypt", "sign", "verify"]
+  depends_on = [
+    azurerm_role_assignment.current_oai_key_vault_admin,
+    azurerm_role_assignment.admin_oai_key_vault_crypto,
+  ]
 
   rotation_policy {
     automatic {

--- a/terraform/research_env.tf
+++ b/terraform/research_env.tf
@@ -42,6 +42,10 @@ resource "azurerm_key_vault_secret" "research_config" {
   name         = "research-config"
   key_vault_id = azurerm_key_vault.main.id
   value        = local.research_env_toml
+  depends_on = [
+    azurerm_role_assignment.current_key_vault_admin,
+    azurerm_role_assignment.admin_key_vault_secrets,
+  ]
 }
 
 resource "azurerm_key_vault_secret" "research_password" {
@@ -49,6 +53,10 @@ resource "azurerm_key_vault_secret" "research_password" {
   name         = "research-password"
   key_vault_id = azurerm_key_vault.main.id
   value        = var.research_password
+  depends_on = [
+    azurerm_role_assignment.current_key_vault_admin,
+    azurerm_role_assignment.admin_key_vault_secrets,
+  ]
 }
 
 resource "azurerm_container_app" "research" {


### PR DESCRIPTION
Azure has deprecated KeyVault access policies, and only RBAC will be available starting next year. This PR migrates deprecated access policies on our KeyVaults and configures RBAC, per the migration guide here: https://learn.microsoft.com/en-us/azure/key-vault/general/rbac-migration?tabs=cli