### PR TITLE
Set up cert expiry alert

### DIFF
--- a/terraform/key_vault.tf
+++ b/terraform/key_vault.tf
@@ -32,6 +32,16 @@ resource "azurerm_key_vault" "main" {
   tenant_id = azurerm_user_assigned_identity.admin.tenant_id
 }
 
+resource "azurerm_monitor_diagnostic_setting" "key_vault" {
+  name                       = "key-vault"
+  target_resource_id         = azurerm_key_vault.main.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+
+  enabled_log {
+    category = "AuditEvent"
+  }
+}
+
 # NOTE(jnu): When OpenAI is deployed in a separate location from the main resources,
 # we need a dedicated key vault in that location.
 resource "azurerm_key_vault" "oai" {

--- a/terraform/monitor.tf
+++ b/terraform/monitor.tf
@@ -237,6 +237,39 @@ resource "azurerm_monitor_metric_alert" "redis_used_memory" {
   }
 }
 
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "key_vault_certificate_near_expiry" {
+  name                 = lower(format("%s-kv-cert-near-expiry", local.name_prefix))
+  resource_group_name  = azurerm_resource_group.main.name
+  location             = azurerm_resource_group.main.location
+  scopes               = [azurerm_log_analytics_workspace.main.id]
+  description          = "Alert when Key Vault emits a certificate near-expiry audit event."
+  severity             = 2
+  evaluation_frequency = "PT1H"
+  window_duration      = "PT1H"
+  enabled              = true
+  tags                 = var.tags
+
+  criteria {
+    query = <<-QUERY
+      AzureDiagnostics
+      | where ResourceId =~ "${azurerm_key_vault.main.id}"
+      | where Category == "AuditEvent"
+      | where OperationName in~ ("CertificateNearExpiry", "CertificateNearExpiryEventGridNotification")
+    QUERY
+
+    time_aggregation_method = "Count"
+    operator                = "GreaterThan"
+    threshold               = 0
+  }
+
+  action {
+    action_groups = concat(
+      [azurerm_monitor_action_group.resource_owner_alerts.id],
+      azurerm_monitor_action_group.email_alerts[*].id,
+    )
+  }
+}
+
 resource "azurerm_monitor_private_link_scope" "main" {
   name                  = lower(format("%s-ampls", local.application_insights_name))
   resource_group_name   = azurerm_resource_group.main.name


### PR DESCRIPTION
Instrument alerting about Certificate expiration. This is somehow not supported as a first-class metric in Azure, so it involves a roundabout method of enabling Audit Diagnostic Events in the KeyVault, exporting them to the LAW, then setting up a custom scheduled query for the Audit Event and firing an alert when it matches.

Alert notifications trigger the same recipients as other new alerts.